### PR TITLE
updating with infra page

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -30,3 +30,40 @@ figure.projects-image img {
     max-height: 4em;
     max-width: 35%;
 }
+
+
+// Infrastructure page
+p.highlight {
+    width: 90%;
+    text-align: center;
+    margin: 1em auto;
+    font-size: 1.2em;
+    font-style: italic;
+}
+
+div.project-figures {
+    margin-top: 4em;
+
+    figure.project-highlight {
+        width: 33%;
+        float: left;
+        height: 11em;
+        text-align: center;
+
+        img {
+            margin: 0 auto;
+            height: 3em;
+        }
+
+        p.project-title {
+            font-size: 1.3em;
+            margin-bottom: .2em;
+        }
+
+        p.project-caption {
+            max-width: 80%;
+            margin: 0 auto;
+        }
+    }
+}
+

--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -9,6 +9,11 @@
   weight = 10
 
 [[main]]
+  name = "Hosted Infrastructure"
+  url = "infrastructure/"
+  weight = 10
+
+[[main]]
   name = "Contact"
   url = "#contact"
   weight = 60

--- a/content/home/about/about.md
+++ b/content/home/about/about.md
@@ -22,6 +22,6 @@ computing in science and education. It has the following core goals:
   in interactive computing.
 * build and support open source tools and communities in this ecosystem.
 
-[2i2c's founding team](/about) has years of experience in infrastructure for interactive
-computing in research and education, and are core members of many large open source
-projects.
+[2i2c's founding team](/about) has years of experience in
+[infrastructure for interactive computing](/infrastructure) in research and education,
+and are core members of many large open source projects.

--- a/content/home/about/getinvolved.md
+++ b/content/home/about/getinvolved.md
@@ -18,8 +18,11 @@ We also seek to employ technologists with expertise in cloud infrastructure,
 dev-ops, and data science, as well as experience in the open source stack of
 tools for science and education.
 
-* **If you are a funder interested in supporting 2i2c**, [get in touch](#contact).
-* **If your organization is interested in hosted Jupyter environments** on
-  cloud infrastructure, [get in touch](#contact)
-* **If you are a researcher or educator who would like to collaborate** on projects, [get in touch](#contact)
-* **If you are interested in working for 2i2c**, [get in touch](#contact).
+* If you are a funder interested in supporting 2i2c, [get in touch](mailto:colliand@2i2c.org?subject=Inquiry%20from%20funder).
+* If your organization is interested in hosted Jupyter environments on
+  cloud infrastructure, [get in touch](mailto:colliand@2i2c.org?subject=Inquiry%20about%20hosted%20jupyter)
+* If you are a researcher or educator who would like to collaborate on projects, [get in touch](mailto:colliand@2i2c.org?subject=Inquiry%20about%20collaboration)
+* If you are interested in working for 2i2c, [get in touch](mailto:colliand@2i2c.org?subject=Inquiry%20about%20employment).
+
+If you'd like updates about 2i2c as it grows and evolves, fill out the form
+below and we will be in touch!

--- a/content/infrastructure/index.md
+++ b/content/infrastructure/index.md
@@ -1,0 +1,5 @@
++++
+# Homepage
+type = "widget_page"
+headless = false  # Homepage is headless, other widget pages are not.
++++

--- a/content/infrastructure/intro.md
+++ b/content/infrastructure/intro.md
@@ -1,0 +1,90 @@
++++
+# Homepage
+type = "blank"
+headless = true  # Homepage is headless, other widget pages are not.
+weight = 1
+title = "We offer open infrastructure"
+
+[design]
+  columns = "1"
++++
+
+2i2c powers research and education by offering hosted interactive computing environments
+that runs on the infrastructure of your choice and is powered by entirely open-source
+technology. This page describes some of the open infrastructure that we specialize in and
+support.
+
+<p class="highlight">2i2c believes that transformational science and education should be built on open-source, community-driven, vendor-agnostic tools.
+</p>
+
+## Benefits of using open infrastructure
+
+Using open infrastructure has several advantages:
+
+- Open tools are the most **powerful, flexible, and dynamic** tools for learning, research,
+  and collaboration.
+- Open tools give you the freedom to **run on many kinds of infrastructure**. They can
+  provide quick access to fast environments, large datasets, or high-powered compute.
+- Open tools **avoid vendor lock-in** - JupyterHub can be deployed anywhere, by anyone.
+  The stack it powers can run on a variety of vendor infrastructure, or your own
+  computer. You can run the entire 2i2c stack on your own if you wish!
+- Open tools are **standards in data science**. They are ubiquitous across academia and industry,
+  and using them will help you connect with the broader research and education community.
+- Open tools align with the **values of research and education**. They rely on contributions
+  from a broad, diverse, and large OS community that is made up of many stakeholders
+  dedicated to creating public goods.
+- Open tools make research and education **more accessible to all**
+
+2i2c integrates an entirely open stack with hosted infrastructure that is tailored for research and
+education, running in the cloud infrastructure of your choice. It also contributes
+back to the communities that develop and grow these tools, keeping the ecosystem
+healthy.
+
+## Open tools that we use and support
+
+Here are a few of the core tools in our interactive environments:
+
+<div class="project-figures">
+{{< figure
+    target="https://jupyter.org"
+    src="https://jupyter.org/assets/nav_logo.svg"
+    title="<p class='project-title'>Jupyter Notebooks</p><p class='project-caption'>Interactive documents for research and education.</p>"
+    class="project-highlight"
+>}}
+
+{{< figure
+    target="https://jupyterlab.readthedocs.io/en/stable/"
+    src="https://avatars3.githubusercontent.com/u/22800682?s=400&v=4"
+    title="<p class='project-title'>Jupyter Lab</p><p class='project-caption'>A customizable and extensible data science interface</p>"
+    class="project-highlight"
+>}}
+
+{{< figure
+    target="https://jupyter.org/hub"
+    src="https://jupyter.org/assets/hublogo.svg"
+    title="<p class='project-title'>JupyterHub</p><p class='project-caption'> Cloud-based computing environments for groups</p>"
+    class="project-highlight"
+>}}
+
+{{< figure
+    target="https://xarray.pydata.org/en/stable/"
+    src="https://xarray.pydata.org/en/stable/_static/dataset-diagram-logo.png"
+    title="<p class='project-title'>XArray</p><p class='project-caption'> N-D labeled arrays and datasets in Python</p>"
+    class="project-highlight"
+>}}
+
+{{< figure
+    target="https://jupyterbook.org/intro.html"
+    src="https://jupyterbook.org/_static/logo.png"
+    title="<p class='project-title'>Jupyter Book</p><p class='project-caption'>Interactive, beautiful books with Jupyter</p>"
+    class="project-highlight"
+>}}
+
+
+{{< figure
+    target="https://docs.dask.org/en/latest/logos.html"
+    src="https://docs.dask.org/en/latest/_images/dask_horizontal.svg"
+    title="<p class='project-title'>Dask</p><p class='project-caption'>Advanced parallelism for analytics</p>"
+    class="project-highlight"
+>}}
+</div>


### PR DESCRIPTION
This adds an infrastructure page that explains some of the open source tools in which we specialize (and that we can deploy). The goal is to get a bit more information about the stack we can offer with 2i2c.

It also changes the "get in touch" links to be `mailto` for @colliand 's 2i2c email. They're currently just pointing to the Google Form, but I think if someone clicks one of those "get in touch" links we actually want a more direct connection rather than a generic "fill out this form to be on a mailing list" thing.

@colliand, that OK with you re: the email? 

