### PR TITLE
removing roles from about page and adding institutions

### DIFF
--- a/content/about/projects/datahub.md
+++ b/content/about/projects/datahub.md
@@ -3,17 +3,17 @@
 type = "blank"
 headless = true  # Homepage is headless, other widget pages are not.
 weight = 41
-title = "The Berkeley DataHub"
+title = "Jupyter at Berkeley"
 
 [design]
   columns = "2"
 +++
 
-{{< figure src="https://brand.berkeley.edu/wp-content/uploads/2016/11/primarylogo.png" class="projects-image" >}}
+{{< figure src="https://jupyter.org/assets/nav_logo.svg" class="projects-image" >}}
 
 [The DataHubs at UC Berkeley](https://ucbds-infra.github.io/ds-course-infra-guide/intro.html)
 are a collection of JupyterHubs used across the
 university's data science courses. These hubs serve thousands of students
 across a variety of courses. 2i2c's team has helped build and maintain these
 hubs, and also assists the university in integrating pedagogical content with
-the datahubs.
+the datahubs and other Jupyter infrastructure.

--- a/content/authors/cathryn-carson/_index.md
+++ b/content/authors/cathryn-carson/_index.md
@@ -10,12 +10,12 @@ authors:
 superuser: true
 
 # Role/position (e.g., Professor of Artificial Intelligence)
-role: UC Berkeley
+role:
 
 # Organizations/Affiliations
 organizations:
 - name: UC Berkeley
-  url: "https://berkeley.edu"
+  url: "https://history.berkeley.edu/cathryn-carson"
 
 # Short bio (displayed in user profile at end of posts)
 bio: Cathryn Bio

--- a/content/authors/chris-holdgraf/_index.md
+++ b/content/authors/chris-holdgraf/_index.md
@@ -10,17 +10,17 @@ authors:
 superuser: true
 
 # Role/position (e.g., Professor of Artificial Intelligence)
-role: UC Berkeley, Project Jupyter
+role:
 
 # Organizations/Affiliations
 organizations:
 - name: UC Berkeley
-  url: "https://berkeley.edu"
+  url: "https://bids.berkeley.edu/people/chris-holdgraf"
 - name: Project Jupyter
   url: "https://jupyter.org"
 
 # Short bio (displayed in user profile at end of posts)
-bio: Testing testing
+bio:
 
 # List each interest with a dash
 interests: []
@@ -48,3 +48,5 @@ email: "choldgraf@berkeley.edu"
 user_groups:
 - Founders
 ---
+
+Chris is a post-doctoral researcher in the Department of Statistics and a Community Architect with the Division of Data Science at Berkeley. His background is in cognitive and computational neuroscience, where he used predictive models to understand the auditory system in the human brain. He is also a team member of Project Jupyter, with a focus on how infrastructure can support interactive computing workflows in research and education. He's interested in the boundary between technology, open-source software, and scientific workflows, as well as how open communities can support and extend these workflows in a way that makes science more impactful and inclusive.

--- a/content/authors/fernando-perez/_index.md
+++ b/content/authors/fernando-perez/_index.md
@@ -10,17 +10,17 @@ authors:
 superuser: true
 
 # Role/position (e.g., Professor of Artificial Intelligence)
-role: UC Berkeley
+role:
 
 # Organizations/Affiliations
 organizations:
 - name: UC Berkeley
-  url: "https://berkeley.edu"
+  url: "https://statistics.berkeley.edu/people/fernando-perez"
 - name: Project Jupyter
   url: "https://jupyter.org"
 
 # Short bio (displayed in user profile at end of posts)
-bio: Fernando Bio
+bio:
 
 # List each interest with a dash
 interests: []

--- a/content/authors/jim-colliander/_index.md
+++ b/content/authors/jim-colliander/_index.md
@@ -10,13 +10,15 @@ authors:
 superuser: true
 
 # Role/position (e.g., Professor of Artificial Intelligence)
-role: PIMS, Syzygy
+role:
 
 # Organizations/Affiliations
-organizations: []
+organizations:
+  - name: The Pacific Institute for Mathematical Sciences
+    url: https://www.pims.math.ca/pims-glance/scientific-review-panel
 
 # Short bio (displayed in user profile at end of posts)
-bio: Jim's Bio
+bio:
 
 # List each interest with a dash
 interests: []

--- a/content/authors/ryan-abernathy/_index.md
+++ b/content/authors/ryan-abernathy/_index.md
@@ -10,13 +10,15 @@ authors:
 superuser: true
 
 # Role/position (e.g., Professor of Artificial Intelligence)
-role: Columbia University, Pangeo
+role:
 
 # Organizations/Affiliations
-organizations: []
+organizations:
+  - name: Columbia University
+    url: https://ocean-transport.github.io/
 
 # Short bio (displayed in user profile at end of posts)
-bio: Ryan Bio
+bio:
 
 # List each interest with a dash
 interests: []

--- a/content/authors/yuvi-panda/_index.md
+++ b/content/authors/yuvi-panda/_index.md
@@ -10,13 +10,15 @@ authors:
 superuser: true
 
 # Role/position (e.g., Professor of Artificial Intelligence)
-role: UC Berkeley, Project Jupyter
+role:
 
 # Organizations/Affiliations
-organizations: []
+organizations:
+  - name: UC Berkeley
+    url: https://data.berkeley.edu/people/yuvi-panda
 
 # Short bio (displayed in user profile at end of posts)
-bio: Yuvi bio...
+bio:
 
 # List each interest with a dash
 interests: []

--- a/content/home/about/getinvolved.md
+++ b/content/home/about/getinvolved.md
@@ -25,4 +25,4 @@ tools for science and education.
 * If you are interested in working for 2i2c, [get in touch](mailto:colliand@2i2c.org?subject=Inquiry%20about%20employment).
 
 If you'd like updates about 2i2c as it grows and evolves, fill out the form
-below and we will be in touch!
+below to add yourself to our mailing list, and we will be in touch!


### PR DESCRIPTION
Removes our institutional affiliations from the "about us" page and adds them instead as links on our individual bio pages. Also softens some "institutional branding" around the "experience" section.

preview: https://deploy-preview-13--cocky-booth-e7ed17.netlify.app/about/

cc @clcarson in case she has suggestions for further edits