### PR TITLE
Non profit initiative + steering council

### DIFF
--- a/content/about/team.md
+++ b/content/about/team.md
@@ -7,7 +7,7 @@ weight = 20
 [content]
   # Choose which groups/teams of users to display.
   #   Edit `user_groups` in each user's profile to add them to one or more of these groups.
-  user_groups = ["Staff", "Volunteer Staff", "Advisory Board"]
+  user_groups = ["Staff", "Volunteer Staff", "Steering Council"]
 
 [design]
   # Show user's social networking links? (true/false)

--- a/content/about/team.md
+++ b/content/about/team.md
@@ -7,7 +7,7 @@ weight = 20
 [content]
   # Choose which groups/teams of users to display.
   #   Edit `user_groups` in each user's profile to add them to one or more of these groups.
-  user_groups = ["Staff", "Volunteer Staff", "Steering Council"]
+  user_groups = ["Open Engineering Team", "Steering Council"]
 
 [design]
   # Show user's social networking links? (true/false)

--- a/content/about/values.md
+++ b/content/about/values.md
@@ -9,7 +9,7 @@ title = "Our values and principles"
   columns = "1"
 +++
 
-As a non-profit organization that is defined and driven by our mission, we believe
+As a non-profit initiative that is defined and driven by our mission, we believe
 that values are crucial to accomplishing our goals in a way that is equitable
 and accessible to all.
 

--- a/content/authors/cathryn-carson/_index.md
+++ b/content/authors/cathryn-carson/_index.md
@@ -10,7 +10,7 @@ authors:
 superuser: true
 
 # Role/position (e.g., Professor of Artificial Intelligence)
-role: Advisory Board
+role: Co-Founder
 
 # Organizations/Affiliations
 organizations:
@@ -36,5 +36,5 @@ email: ""
 #   Set this to `[]` or comment out if you are not using People widget.
 user_groups:
 - Founders
-- Advisory Board
+- Steering Council
 ---

--- a/content/authors/chris-holdgraf/_index.md
+++ b/content/authors/chris-holdgraf/_index.md
@@ -53,6 +53,7 @@ email: "choldgraf@berkeley.edu"
 user_groups:
 - Founders
 - Staff
+- Steering Council
 ---
 
 Chris is the Director of 2i2c. He was previously a post-doctoral researcher in the Department of Statistics at [UC Berkeley](https://www.berkeley.edu/), and a Community Architect with the [Division of Data Science](https://data.berkeley.edu/) at Berkeley. He is also a team member of Project Jupyter (particularly the [JupyterHub and Binder teams](https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#jupyterhub-team)), with a focus on how infrastructure can support interactive computing workflows in research and education. He's interested in the boundary between technology, open-source software, and research and education workflows, as well as how open communities can support and extend these workflows in a way that makes science more impactful and inclusive. His background is in cognitive and computational neuroscience, where he used [predictive models to understand the auditory system](https://www.nature.com/articles/ncomms13654) in the human brain.

--- a/content/authors/chris-holdgraf/_index.md
+++ b/content/authors/chris-holdgraf/_index.md
@@ -52,8 +52,8 @@ email: "choldgraf@berkeley.edu"
 #   Set this to `[]` or comment out if you are not using People widget.
 user_groups:
 - Founders
-- Staff
 - Steering Council
+- Open Engineering Team
 ---
 
 Chris is the Director of 2i2c. He was previously a post-doctoral researcher in the Department of Statistics at [UC Berkeley](https://www.berkeley.edu/), and a Community Architect with the [Division of Data Science](https://data.berkeley.edu/) at Berkeley. He is also a team member of Project Jupyter (particularly the [JupyterHub and Binder teams](https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#jupyterhub-team)), with a focus on how infrastructure can support interactive computing workflows in research and education. He's interested in the boundary between technology, open-source software, and research and education workflows, as well as how open communities can support and extend these workflows in a way that makes science more impactful and inclusive. His background is in cognitive and computational neuroscience, where he used [predictive models to understand the auditory system](https://www.nature.com/articles/ncomms13654) in the human brain.

--- a/content/authors/erik-sundell/_index.md
+++ b/content/authors/erik-sundell/_index.md
@@ -50,7 +50,6 @@ social:
 #   Set this to `[]` or comment out if you are not using People widget.
 user_groups:
 - Open Engineering Team
-- Staff
 ---
 
 Attracted by an inclusive culture and a leverage for a positive world impact,

--- a/content/authors/fernando-perez/_index.md
+++ b/content/authors/fernando-perez/_index.md
@@ -10,7 +10,7 @@ authors:
 superuser: true
 
 # Role/position (e.g., Professor of Artificial Intelligence)
-role: Advisory Board
+role: Co-Founder
 
 # Organizations/Affiliations
 organizations:
@@ -38,5 +38,5 @@ social: []
 #   Set this to `[]` or comment out if you are not using People widget.
 user_groups:
 - Founders
-- Advisory Board
+- Steering Council
 ---

--- a/content/authors/georgiana-dolocan/_index.md
+++ b/content/authors/georgiana-dolocan/_index.md
@@ -47,7 +47,6 @@ social:
 #   Set this to `[]` or comment out if you are not using People widget.
 user_groups:
 - Open Engineering Team
-- Staff
 ---
 
 Software Engineer irreversibly in love with open source. A JupyterHub team member, focusing on infrastructure and community growth. Previously JupyterHub Contributor in Residence and Outreachy intern through an internship that supports diversity in open source and free software.

--- a/content/authors/jim-colliander/_index.md
+++ b/content/authors/jim-colliander/_index.md
@@ -10,7 +10,7 @@ authors:
 superuser: true
 
 # Role/position (e.g., Professor of Artificial Intelligence)
-role: Advisory Board
+role: Co-Founder
 
 # Organizations/Affiliations
 organizations:
@@ -36,5 +36,5 @@ email: ""
 #   Set this to `[]` or comment out if you are not using People widget.
 user_groups:
 - Founders
-- Advisory Board
+- Steering Council
 ---

--- a/content/authors/lindsey-heagy/_index.md
+++ b/content/authors/lindsey-heagy/_index.md
@@ -10,7 +10,7 @@ authors:
 superuser: true
 
 # Role/position (e.g., Professor of Artificial Intelligence)
-role: Advisory Board
+role: Co-Founder
 
 # Organizations/Affiliations
 organizations:
@@ -36,5 +36,5 @@ email: ""
 #   Set this to `[]` or comment out if you are not using People widget.
 user_groups:
 - Founders
-- Advisory Board
+- Steering Council
 ---

--- a/content/authors/ryan-abernathey/_index.md
+++ b/content/authors/ryan-abernathey/_index.md
@@ -10,7 +10,7 @@ authors:
 superuser: true
 
 # Role/position (e.g., Professor of Artificial Intelligence)
-role: Advisory Board
+role: Co-Founder
 
 # Organizations/Affiliations
 organizations:
@@ -45,5 +45,5 @@ email: ""
 #   Set this to `[]` or comment out if you are not using People widget.
 user_groups:
 - Founders
-- Advisory Board
+- Steering Council
 ---

--- a/content/authors/yuvi-panda/_index.md
+++ b/content/authors/yuvi-panda/_index.md
@@ -10,7 +10,7 @@ authors:
 superuser: true
 
 # Role/position (e.g., Professor of Artificial Intelligence)
-role: Director of Engineering
+role: Volunteer Director of Engineering
 
 # Organizations/Affiliations
 organizations:
@@ -47,6 +47,7 @@ user_groups:
 - Founders
 - Open Engineering Team
 - Volunteer Staff
+- Steering Council
 ---
 
 Building participatory open infrastructure for scientific & educational use cases. A Project Jupyter team member working on infrastructure related projects. Ex Wikimedia and ex-GNOME. Let's eliminate accidental complexities wherever we find them.

--- a/content/authors/yuvi-panda/_index.md
+++ b/content/authors/yuvi-panda/_index.md
@@ -10,7 +10,7 @@ authors:
 superuser: true
 
 # Role/position (e.g., Professor of Artificial Intelligence)
-role: Volunteer Director of Engineering
+role: Director of Engineering
 
 # Organizations/Affiliations
 organizations:
@@ -46,7 +46,6 @@ email: ""
 user_groups:
 - Founders
 - Open Engineering Team
-- Volunteer Staff
 - Steering Council
 ---
 

--- a/content/authors/yuvi-panda/_index.md
+++ b/content/authors/yuvi-panda/_index.md
@@ -10,7 +10,7 @@ authors:
 superuser: true
 
 # Role/position (e.g., Professor of Artificial Intelligence)
-role: Director of Engineering
+role: Volunteer Director of Engineering
 
 # Organizations/Affiliations
 organizations:

--- a/content/home/hero.md
+++ b/content/home/hero.md
@@ -47,4 +47,4 @@ hero_media = "2i2c-hub-overview.png"
 #  label = '2i2c provides open-source infrastructure for interactive computing at institutions of research and education.'
 +++
 
-2i2c is a mission-driven non-profit that develops, deploys, customizes, and manages open source tools for interactive computing in research and education.
+2i2c is a non-profit initiative that develops, deploys, customizes, and manages open source tools for interactive computing in research and education.

--- a/content/home/mission.md
+++ b/content/home/mission.md
@@ -10,7 +10,7 @@ title = "What we do"
   columns = "1"
 +++
 
-2i2c is a non-profit that makes interactive computing more accessible and powerful for research and education. We strive to **accelerate research and discovery**, and to **empower education** to be more accessible, intuitive, and enjoyable. We do this through these primary actions:
+We make interactive computing more accessible and powerful for research and education. We strive to **accelerate research and discovery**, and to **empower education** to be more accessible, intuitive, and enjoyable. We do this through these primary actions:
 
 <div class="card-group mission-cards">
     <div class="card w-50 m-3" style="width: 18rem;">

--- a/content/job/osie-pangeo/index.md
+++ b/content/job/osie-pangeo/index.md
@@ -19,7 +19,7 @@ We are looking for an Open Source Infrastructure Engineer who will help shape th
 
 ## Who we are
 
-2i2c is a non-profit organization with a mission to make interactive computing more accessible, scalable, and powerful for research and education. We strive to...
+2i2c is a non-profit initiative with a mission to make interactive computing more accessible, scalable, and powerful for research and education. We strive to...
 
 *   Support data workflows in research and education through infrastructure for interactive computing.
 *   Support open tools and communities that underlie this infrastructure.

--- a/content/posts/czi-core-support/index.md
+++ b/content/posts/czi-core-support/index.md
@@ -10,7 +10,7 @@ featured: false
 draft: false
 ---
 
-Last week we [announced the creation of 2i2c](/posts/hello-word), a non-profit dedicated to improving and facilitating access to infrastructure for interactive computing workflows in research and education. Today we are thrilled to announce that 2i2c has received core support from the [Chan Zuckerberg Initiative](https://chanzuckerberg.com/). You can find [CZI's announcement here](https://cziscience.medium.com/scaling-open-infrastructure-and-reproducibility-in-biomedicine-69546a399747).
+Last week we [announced the creation of 2i2c](/posts/hello-word), a non-profit initiative dedicated to improving and facilitating access to infrastructure for interactive computing workflows in research and education. Today we are thrilled to announce that 2i2c has received core support from the [Chan Zuckerberg Initiative](https://chanzuckerberg.com/). You can find [CZI's announcement here](https://cziscience.medium.com/scaling-open-infrastructure-and-reproducibility-in-biomedicine-69546a399747).
 
 This funding totals around $1.4m over three years. It provides crucial core support for 2i2c as it bootstraps itself into existence. We are so thankful to CZI for this support. 🎉🙏✨
 

--- a/content/posts/hello-world/index.md
+++ b/content/posts/hello-world/index.md
@@ -32,7 +32,7 @@ We created 2i2c so that these organizations can use entirely open-source tools w
 
 ## Why a non-profit?
 
-It may sound strange to create a non-profit organization when there are many VC-funded startups and large tech companies offering notebook services these days. However, we think that a non-profit organization is the right approach to balance the interests of all the stakeholders that we wish to serve. We hope that 2i2c will be a partner to:
+It may sound strange to create a non-profit initiative when there are many VC-funded startups and large tech companies offering notebook services these days. However, we think that a non-profit organization is the right approach to balance the interests of all the stakeholders that we wish to serve. We hope that 2i2c will be a partner to:
 
 - **Research and educational communities**, who can rely on 2i2c to provide them cutting-edge infrastructure for interactive computing that is 💯 open source.
 - **Researchers and educators who need development**, who can rely on 2i2c as a collaborator that provides development and expertise in open-source infrastructure to push the cutting edge of interactive computing in the cloud.
@@ -40,7 +40,7 @@ It may sound strange to create a non-profit organization when there are many VC-
 - **Cloud providers**, who wish to help the research and educational community via their infrastructure.
 - **Supporters of open source** who wish to support interactive computing for research and education via a non-profit dedicated to exactly this mission.
 
-As a non-profit, 2i2c is dedicated to supporting an ecosystem of tools and stakeholders across the open source community, and to ensuring that those tools are well-suited for research and education. We believe strongly in mission-driven work, and non-profit status will ensure that the work that we do is always aligned with our mission and values.
+As a non-profit initiative, 2i2c is dedicated to supporting an ecosystem of tools and stakeholders across the open source community, and to ensuring that those tools are well-suited for research and education. We believe strongly in mission-driven work, and non-profit status will ensure that the work that we do is always aligned with our mission and values.
 
 ## What are we going to do?
 
@@ -68,7 +68,7 @@ We'll also use these pilots to **develop an organizational sustainability model*
 
 ## What do we need?
 
-As a non-profit organization, 2i2c has a long road ahead of it. We cannot take venture capital funding, so we have to raise funds the old-fashioned way. This means that:
+As a non-profit initiative, 2i2c has a long road ahead of it. We cannot take venture capital funding, so we have to raise funds the old-fashioned way. This means that:
 
 - If you are at an organization interested in purchasing hosted JupyterHub environments from 2i2c, please [send us an email <i class="fas fa-envelope"></i>](mailto:hello@2i2c.org).
 - If you are a funder or are otherwise interested in supporting 2i2c with a donation or grant, please [send us an email <i class="fas fa-envelope"></i>](mailto:hello@2i2c.org).


### PR DESCRIPTION
This PR does two things:

- Uses the language "non-profit initiative" to make it clear that 2i2c is not a non-profit
- Renames the Advisory Board to be the "Steering Council", because I believe Advisory Board has specific legal connotations that we don't want to convey.
- Renames "Staff" to instead use the more generic "Team". Staff also conveys specific legal connections, while "team" is more flexible.