### PR TITLE
Restructure hero section on home page

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -8,7 +8,7 @@ section.wg-blank {
 
 // Home page
 h1.hero-title {
-    font-size: 2rem;
+    max-width: 768px;
 }
 
 .wg-hero {

--- a/content/home/hero.md
+++ b/content/home/hero.md
@@ -5,10 +5,10 @@ headless = true  # This file represents a page section.
 active = true  # Activate this widget? true/false
 weight = 100  # Order that this section will appear.
 
-title = "Interactive computing infrastructure for your <span class='text-success font-weight-bold'>community</span>."
+title = "<span class=' font-weight-bold'>Interactive computing infrastructure</span> <small>for your community</small>"
 
 # Hero image (optional). Enter filename of an image in the `static/media/` folder.
-hero_media = "2i2c-hub-overview.png"
+hero_media = ""
 
 [design.background]
   # Apply a background color, gradient, or image.


### PR DESCRIPTION
- Remove architecture diagram
- Restrict max width of hero title, provide whitespace on
  the other side that looks nice
- Give hero headers their original size back, since we have
  the extra space now
- Put the focus on 'Interactive computing infrastructure', a
  sentence fragment, than on just the word 'community'
- Use font weights & sizes for emphasis, rather than color.
  We don't have any other green in our branding or website
  either.


Before: 
<img width="1294" alt="image" src="https://user-images.githubusercontent.com/30430/112188411-fa3fd580-8c28-11eb-99ae-109e7696a259.png">

After:
<img width="1310" alt="image" src="https://user-images.githubusercontent.com/30430/112188445-0330a700-8c29-11eb-89eb-f795b4b338c9.png">
