### PR TITLE
Cleanup 'contact' segment in home page

### DIFF
--- a/content/home/contact.md
+++ b/content/home/contact.md
@@ -1,6 +1,6 @@
 +++
 # Contact widget.
-widget = "contact"  # See https://sourcethemes.com/academic/docs/page-builder/
+widget = "blank"  # See https://sourcethemes.com/academic/docs/page-builder/
 headless = true  # This file represents a page section.
 active = true  # Activate this widget? true/false
 weight = 410  # Order that this section will appear.
@@ -11,13 +11,12 @@ subtitle = ""
 # Automatically link email and phone?
 autolink = false
 
-# Email form provider
-#   0: Disable email form
-#   1: Netlify (requires that the site is hosted by Netlify)
-#   2: formspree.io
-email_form = 0
+[design]
+  columns = "1"
 +++
 
-If you've got a question about 2i2c or would like to inquire about hosted 2i2c Hubs, [send us an email <i class="fas fa-envelope"></i>](mailto:hello@2i2c.org). If you'd like to be updated as 2i2c grows and evolves, fill out the form below.
+If you've got a question about 2i2c or would like to inquire about hosted 2i2c Hubs, [send us an email <i class="fas fa-envelope"></i>](mailto:hello@2i2c.org). 
 
-<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSdW_bhVrXfgRYa9Ct6w399KQPILbU_3nKUF_tgnGZJbs91SXg/viewform?embedded=true" width="640" height="1000" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+If you'd like to be updated as 2i2c grows and evolves, fill out the form below.
+
+<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSdW_bhVrXfgRYa9Ct6w399KQPILbU_3nKUF_tgnGZJbs91SXg/viewform?embedded=true" width="640" height="1200" frameborder="0" marginheight="0" marginwidth="0" class="embed-responsive">Loading…</iframe>


### PR DESCRIPTION
- Was a somewhat strange 2 column layout due to use of
  contact section template. Removed that, since we don't
  actually use any of the features there
- Make width of form iframe responsive. This also centers
  it horizontally
- Increase width of iframe to prevent scrolling in the
  form. This should get a more robust solution.