### PR TITLE
Lighter shade of blue

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -13,7 +13,7 @@
 #   Latest themes (may require updating): https://sourcethemes.com/academic/themes/
 #   Browse built-in themes in `themes/academic/data/themes/`
 #   Browse user installed themes in `data/themes/`
-theme = "minimal"
+theme = "2i2c"
 
 # Enable users to switch between day and night mode?
 day_night = false

--- a/data/themes/2i2c.toml
+++ b/data/themes/2i2c.toml
@@ -6,12 +6,12 @@ name = "2i2c"
 light = true
 
 # Primary
-primary = "#7eade0"
+primary = "rgb(87, 154, 202)"  # Binder blue
 
 # Menu
 menu_primary = "#fff"
 menu_text = "#34495e"
-menu_text_active = "#7eade0"
+menu_text_active = "rgb(87, 154, 202)"
 menu_title = "#2b2b2b"
 
 # Home sections

--- a/data/themes/2i2c.toml
+++ b/data/themes/2i2c.toml
@@ -1,0 +1,23 @@
+# This is just the Minimal theme with primary / menu_text_active updated to a lighter shade of blue.
+# Theme metadata
+name = "2i2c"
+
+# Is theme light or dark?
+light = true
+
+# Primary
+primary = "#7eade0"
+
+# Menu
+menu_primary = "#fff"
+menu_text = "#34495e"
+menu_text_active = "#7eade0"
+menu_title = "#2b2b2b"
+
+# Home sections
+home_section_odd = "rgb(255, 255, 255)"
+home_section_even = "rgb(247, 247, 247)"
+
+[dark]
+  link = "#bbdefb"
+  link_hover = "#bbdefb"


### PR DESCRIPTION
This sets our `blue` shade to the same blue that Binder uses. This complements our grey a bit better and makes it less jarring, it also is a nice tie-in with the Binder world. It also compliments the update at https://github.com/2i2c-org/pilot/pull/97