### PR TITLE
Add two notes about the job

### DIFF
--- a/content/jobs/2022/product-community-lead.md
+++ b/content/jobs/2022/product-community-lead.md
@@ -5,12 +5,13 @@ salary_range = "$120,000 - $130,000"
 location = "anywhere (prefer a time zone between US/Pacific and Central European)"
 date = "2022-02-28"
 url_apply = "https://airtable.com/shrbSTcFNAhKqyy6d?prefill_Applying%20for=Product%20and%20Community%20Lead"
+deadline = "We will begin reviewing applications around **March 21st**, and will accept them on a rolling basis until the position is filled."
 open = "true"
 +++
 
 We are looking for a Product and Community Lead to ensure that the communities that 2i2c serves are empowered to have the most impact with our infrastructure.
 
-<!-- Defined in `layouts/shortcodes/job_details.html -->
+<!-- Defined in layouts/shortcodes/job_details.html -->
 {{% job_details %}}
 
 ## Position summary
@@ -83,3 +84,9 @@ Below are several skills that will make somebody well-suited for this role. Ther
 * An interest in learning about **workflows with the open source language Python**, and open source workflows around it for research and education.
 * Experience or strong interest in **cloud infrastructure and data workflows** for research or education, and how this can lead to more collaboration, openness, and productivity (for example, via managed services and [Analysis Ready, Cloud Optimized datasets](https://eartharxiv.org/repository/view/2726/)).
 * Experience with **distributed and complex open source communities** and ability to communicate and collaborate effectively with these communities.
+
+## A note on scope and expectations
+
+We know that this role is very broad in scope, and that there is a lot of room for interpretation of the specific responsibilities and duties. This is somewhat intentional, and somewhat unavoidable, given that this is the first role of its kind within 2i2c.
+
+We recognize that one risk in these situations is to have unrealistic expectations, or an unsustainable amount of work for the person involved. We'll do everything we can to set these expectations intentionally, and to refine them as we learn more, to ensure that this role is sustainable.

--- a/content/jobs/2022/product-community-lead.md
+++ b/content/jobs/2022/product-community-lead.md
@@ -89,4 +89,4 @@ Below are several skills that will make somebody well-suited for this role. Ther
 
 We know that this role is very broad in scope, and that there is a lot of room for interpretation of the specific responsibilities and duties. This is somewhat intentional, and somewhat unavoidable, given that this is the first role of its kind within 2i2c.
 
-We recognize that one risk in these situations is to have unrealistic expectations, or an unsustainable amount of work for the person involved. We'll do everything we can to set these expectations intentionally, and to refine them as we learn more, to ensure that this role is sustainable.
+We recognize that one risk in these situations is to have unrealistic expectations, or an unsustainable amount of work for the person involved. We'll do everything we can to set these expectations intentionally, and to refine them as we learn more, to ensure that this role is sustainable. The person in this role will need to be comfortable with a larger-than-normal amount of ambiguity and flexibility, though part of their job will be to _reduce_ this ambiguity for themselves and for others in the future.

--- a/content/jobs/2022/product-community-lead.md
+++ b/content/jobs/2022/product-community-lead.md
@@ -87,6 +87,4 @@ Below are several skills that will make somebody well-suited for this role. Ther
 
 ## A note on scope and expectations
 
-We know that this role is very broad in scope, and that there is a lot of room for interpretation of the specific responsibilities and duties. This is somewhat intentional, and somewhat unavoidable, given that this is the first role of its kind within 2i2c.
-
-We recognize that one risk in these situations is to have unrealistic expectations, or an unsustainable amount of work for the person involved. We'll do everything we can to set these expectations intentionally, and to refine them as we learn more, to ensure that this role is sustainable. The person in this role will need to be comfortable with a larger-than-normal amount of ambiguity and flexibility, though part of their job will be to _reduce_ this ambiguity for themselves and for others in the future.
+We know that this role is very broad in scope, and that there is a lot of room for interpretation of the specific responsibilities and duties. This is somewhat intentional, and somewhat unavoidable, given that this is the first role of its kind within 2i2c. We will do everything we can to set these expectations intentionally, and to refine them as we learn more, in order to reduce this ambiguity and ensure that this role is sustainable.

--- a/layouts/shortcodes/job_details.html
+++ b/layouts/shortcodes/job_details.html
@@ -12,6 +12,7 @@ See <a href="/jobs">the jobs page</a> for our open positions.<br>
 
 - **Salary**: {{ .Page.Params.salary_range }}
 - **Location**: {{ .Page.Params.location }}
+- **Deadline**: {{ .Page.Params.deadline }}
 
 For more general information about working at 2i2c, benefits, and expectations of team members, [see our Jobs page](/jobs).
 For a comprehensive guide to 2i2c's team practices and strategy, see [our Team Compass](https://team-compass.2i2c.org).


### PR DESCRIPTION
After some feedback about our job posting, this adds two extra sets of content:

1. Defines the timeline for application
2. Adds a note that we recognize the large scope of this role, and shows our commitment to making this role sustainable for the person involved.