### PR TITLE
Blog post about CZI proposal

### DIFF
--- a/content/blog/2022/2021-review-services/index.md
+++ b/content/blog/2022/2021-review-services/index.md
@@ -4,7 +4,7 @@ subtitle: ""
 summary: ""
 authors: ["Chris Holdgraf"]
 tags: []
-categories: [updates]
+categories: [organization]
 date: 2022-01-25
 featured: false
 draft: false

--- a/content/blog/2022/ci-cd-improvements/index.md
+++ b/content/blog/2022/ci-cd-improvements/index.md
@@ -4,7 +4,7 @@ subtitle: "How we optimised and parallelised deployments of multiple JupyterHubs
 summary: ""
 authors: ["Sarah Gibson"]
 tags: []
-categories: [updates]
+categories: [engineering]
 date: "2022-04-19"
 featured: false
 draft: false

--- a/content/blog/2022/czi-global-communities-proposal/index.md
+++ b/content/blog/2022/czi-global-communities-proposal/index.md
@@ -38,7 +38,7 @@ However, it is also inaccessible to many for a variety of reasons:
 - Running infrastructure in the cloud takes dedicated time and expertise that many communities lack.
 - Many communities do not have organized communities of practice around cloud infrastructure.
 
-These issues are true for most scientific communities, but they are exacerbated in countries that are historically under-represented in the global scientific community.
+These issues are true for most scientific communities, but they are exacerbated in countries that are often marginalized in the global scientific community.
 
 ## Our proposed work
 
@@ -51,7 +51,7 @@ It defines four major areas of collaboration:
 - **Training for trainers** - to provide community leaders with skills to share these workflows with others in their communities.
 - **Community leadership and management** - to provide community leaders with skills to sustain and grow healthy communities of practice.
 
-Over the course of two years, the team will provide a combination of the services described above for communities in Latin America and Africa, with the goal of understanding how such services can be most useful for these communities, how we can structure them to provide community representation in the direction of these services, and how we can sustain and scale this model of community-focused services for a global community.
+If this proposal is funded, over the course of two years the team will provide a combination of the services described above for communities in Latin America and Africa, with the goal of understanding how such services can be most useful for these communities, how we can structure them to provide community representation in the direction of these services, and how we can sustain and scale this model of community-focused services for a global community.
 
 Importantly, we wish to do this work in a way that centers the communities we work with as co-leaders and collaborators in these services.
 We will explore ways to run these services and workshops so that they are transparent, inclusive, and give agency to the communities they support.

--- a/content/blog/2022/czi-global-communities-proposal/index.md
+++ b/content/blog/2022/czi-global-communities-proposal/index.md
@@ -47,14 +47,14 @@ For this reason, our goal in this grant is to **provide human and technical serv
 It defines four major areas of collaboration:
 
 - **Cloud infrastructure management** - to facilitate access to cloud resources via managed cloud services that integrate open source tools.
-- **Application guidance and training** - to provide community leaders with the skills to utilize this infrastructure for the needs. This includes language-localized content and training materials.
+- **Application guidance and training** - to provide community leaders with the skills to utilize this infrastructure for their needs. This includes language-localized content and training materials.
 - **Training for trainers** - to provide community leaders with skills to share these workflows with others in their communities.
 - **Community leadership and management** - to provide community leaders with skills to sustain and grow healthy communities of practice.
 
 Over the course of two years, the team will provide a combination of the services described above for communities in Latin America and Africa, with the goal of understanding how such services can be most useful for these communities, how we can structure them to provide community representation in the direction of these services, and how we can sustain and scale this model of community-focused services for a global community.
 
 Importantly, we wish to do this work in a way that centers the communities we work with as co-leaders and collaborators in these services.
-We will explore ways to run these services and workshops in a way that is transparent, inclusive, and gives agency to these communities.
+We will explore ways to run these services and workshops so that they are transparent, inclusive, and give agency to the communities they support.
 Ultimately, we hope that this can be an extensible model for many more communities in the future.
 
 > If you're interested in this work, would like to discuss its ideas, or think something similar might be useful for your community, please reach out!

--- a/content/blog/2022/czi-global-communities-proposal/index.md
+++ b/content/blog/2022/czi-global-communities-proposal/index.md
@@ -1,0 +1,62 @@
+---
+title: "Open grant narrative: A Collaborative Interactive Computing Service Model for Global Communities"
+subtitle: ""
+summary: ""
+authors: ["Chris Holdgraf"]
+tags: []
+categories: [partnerships]
+date: "2022-08-28"
+featured: false
+draft: false
+---
+
+
+We recently submitted a grant to [Chan Zuckerberg Initiative](https://chanzuckerberg.com/) and wish to share some details about it as well as the grant narrative for others to read and re-use.
+
+{{< cta cta_text="Go to Zenodo record" cta_link="https://zenodo.org/record/7025288" cta_new_tab="true" >}}
+
+Read on for a quick overview of the proposal.
+
+## Collaborators
+
+This grant is a collaboration between several leading organizations in open infrastructure, community, and global leadership:
+
+- [2i2c](https://2i2c.org)
+- [The Carpentries](https://carpentries.org/about/)
+- [Center for Scientific Collaboration and Community Engagement](https://www.cscce.org/)
+- [Invest in Open Infrastructure](https://investinopen.org/)
+- [MetaDocencia](https://www.metadocencia.org/)
+- [Open Life Science](https://openlifesci.org/)
+
+## Problem statement
+
+Cloud infrastructure is a powerful way to broaden access to workflows and infrastructure across the globe.
+However, it is also inaccessible to many for a variety of reasons:
+
+- There is a large, diverse, and messy ecosystem of open source tools to facilitate cloud infrastructure.
+- Most communities don't already have skills in utilizing cloud workflows.
+- Running infrastructure in the cloud takes dedicated time and expertise that many communities lack.
+- Many communities do not have organized communities of practice around cloud infrastructure.
+
+These issues are true for most scientific communities, but they are exacerbated in countries that are historically under-represented in the global scientific community.
+
+## Our proposed work
+
+For this reason, our goal in this grant is to **provide human and technical services to facilitate learning and knowledge transfer of cloud workflows for communities in Latin America and Africa**.
+
+It defines four major areas of collaboration:
+
+- **Cloud infrastructure management** - to facilitate access to cloud resources via managed cloud services that integrate open source tools.
+- **Application guidance and training** - to provide community leaders with the skills to utilize this infrastructure for the needs. This includes language-localized content and training materials.
+- **Training for trainers** - to provide community leaders with skills to share these workflows with others in their communities.
+- **Community leadership and management** - to provide community leaders with skills to sustain and grow healthy communities of practice.
+
+Over the course of two years, the team will provide a combination of the services described above for communities in Latin America and Africa, with the goal of understanding how such services can be most useful for these communities, how we can structure them to provide community representation in the direction of these services, and how we can sustain and scale this model of community-focused services for a global community.
+
+Importantly, we wish to do this work in a way that centers the communities we work with as co-leaders and collaborators in these services.
+We will explore ways to run these services and workshops in a way that is transparent, inclusive, and gives agency to these communities.
+Ultimately, we hope that this can be an extensible model for many more communities in the future.
+
+> If you're interested in this work, would like to discuss its ideas, or think something similar might be useful for your community, please reach out!
+> 
+> {{< cta cta_text="Send us an email" cta_link="mailto:hello@2i2c.org" cta_new_tab="true" >}}

--- a/content/blog/2022/eddy-symposium-report/index.md
+++ b/content/blog/2022/eddy-symposium-report/index.md
@@ -4,7 +4,7 @@ subtitle: ""
 summary: ""
 authors: ["James Colliander"]
 tags: []
-categories: [updates]
+categories: [community]
 date: 2022-07-14
 featured: false
 draft: false

--- a/content/blog/2022/job-product-community-lead/index.md
+++ b/content/blog/2022/job-product-community-lead/index.md
@@ -4,7 +4,7 @@ subtitle: ""
 summary: ""
 authors: ["Chris Holdgraf"]
 tags: []
-categories: [updates]
+categories: [people]
 date: 2022-02-22
 featured: false
 draft: false

--- a/content/blog/2022/product-community-lead-drop-in-notes/index.md
+++ b/content/blog/2022/product-community-lead-drop-in-notes/index.md
@@ -4,7 +4,7 @@ subtitle: ""
 summary: ""
 authors: ["Chris Holdgraf"]
 tags: []
-categories: [updates]
+categories: [people]
 date: 2022-03-22
 featured: false
 draft: false


### PR DESCRIPTION
This adds a CZI proposal along with a link to a Zenodo entry for our recent grant narrative. It also updates a few categories to standardize them with 2i2c's organizational groups.

Here's a preview of the post: https://630dfafa7418ca000922a999--cocky-booth-e7ed17.netlify.app/blog/2022/czi-global-communities-proposal/

I'll leave this PR open for a few hours and will post it later today if there are no objections!

- closes https://github.com/2i2c-org/team-compass/issues/497
