### PR TITLE
Remove dates from job posts

### DIFF
--- a/content/jobs/2021/osie-pangeo.md
+++ b/content/jobs/2021/osie-pangeo.md
@@ -5,6 +5,7 @@ work_description = ["Cloud infrastructure management and operations.", "Developm
 salary_range = "$110,000 - $130,000"
 location = "anywhere (prefer a time zone between US/Pacific and Central European)"
 open = "false"
+show_date = false
 +++
 
 We are looking for an Open Source Infrastructure Engineer who will help shape the future of data-intensive scientific research and make a big impact on important problems shaping society. This engineer will lead the development and operation of cloud-based infrastructure, focusing  on the [Pangeo Project](https://pangeo.io) - a community platform for big data geoscience.

--- a/content/jobs/2022/open-source-infrastructure-engineer.md
+++ b/content/jobs/2022/open-source-infrastructure-engineer.md
@@ -11,7 +11,8 @@ location = "preferred at the US/Pacific time zone"
 date = "2022-10-14"
 url_apply = "https://forms.gle/RPqWHoweDnvUVp4d8"
 deadline = "We will begin reviewing applications around **November 17th**, and will accept them on a rolling basis until the position is filled."
-open = "true"
+open = true
+show_date = false
 +++
 
 2i2c manages, supports, and builds community-centric infrastructure for interactive computing in the cloud with partner communities in research and education.

--- a/content/jobs/2022/product-community-lead.md
+++ b/content/jobs/2022/product-community-lead.md
@@ -6,7 +6,8 @@ location = "anywhere (prefer a time zone between US/Pacific and Central European
 date = "2022-02-28"
 url_apply = "https://airtable.com/shrbSTcFNAhKqyy6d?prefill_Applying%20for=Product%20and%20Community%20Lead"
 deadline = "We will begin reviewing applications around **March 21st**, and will accept them on a rolling basis until the position is filled."
-open = "false"
+open = false
+show_date = false
 +++
 
 We are looking for a Product and Community Lead to ensure that the communities that 2i2c serves are empowered to have the most impact with our infrastructure.

--- a/layouts/shortcodes/job_details.html
+++ b/layouts/shortcodes/job_details.html
@@ -1,7 +1,7 @@
 {{/* This inserts page metadata about a job into an info card on the page */}}
 <div class="job-info">
 
-{{ if ne .Page.Params.open "true" }}
+{{ if ne .Page.Params.open true }}
 ❌❌❌<br>
 This posting is closed to new applications.<br>
 See <a href="/jobs">the jobs page</a> for our open positions.<br>

--- a/layouts/shortcodes/open_jobs.html
+++ b/layouts/shortcodes/open_jobs.html
@@ -1,6 +1,6 @@
 {{/* Grab a list of all files in the jobs folder that are open */}}
 {{ $jobs := .Page.GetPage "jobs/" }}
-{{ $jobs := where $jobs.Pages "Params.open" "true" }}
+{{ $jobs := where $jobs.Pages "Params.open" true }}
 
 {{ if $jobs }}
 <div class="card-group job-cards mb-5">


### PR DESCRIPTION
This removes dates from our job postings. The rationale for this is that job postings may be up for a long time if we can't find a suitable candidate, or if multiple candidates are hired under one posting. If people see an old date then they may be discouraged from applying just because it is in the past. Since the date is not strictly related to the job posting (as long as it is active), then we can juts remove it to avoid this confusion.

It also fixes a boolean check in Hugo to choose whether to show templates. TOML treats `true` and `false` as different from `true` and `false`. I think we want the booleans explicitly instead of strings.