### PR TITLE
Add Damian as Engineering Manager

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -20,7 +20,7 @@
 
   [[main]]
   parent = "about"
-  name = "Organization and team"
+  name = "Team and organization"
   url = "organization/"
   weight = 10
 

--- a/content/authors/damian-avila/_index.md
+++ b/content/authors/damian-avila/_index.md
@@ -10,7 +10,7 @@ authors:
 superuser: false
 
 # Role/position (e.g., Professor of Artificial Intelligence)
-role: Open Source Infrastructure Engineer
+role: Engineering Manager
 
 # Organizations/Affiliations
 organizations:

--- a/content/organization/about.md
+++ b/content/organization/about.md
@@ -14,7 +14,7 @@ We are a distributed team spread across South America, Western and Eastern Europ
 
 {{% callout %}}
 
-[Our Team Compass](https://compass.2i2c.org/en/latest/organization/structure.html) has a lot more information about our organizational structure, goals, and policy.
+[The organizational structure section of our team compass](https://compass.2i2c.org/en/latest/organization/structure.html) has a lot more information about our organizational structure and roles.
 
 {{% /callout %}}
 


### PR DESCRIPTION
This defines @damianavila 's role in 2i2c as "Engineering Manager", it's the implementation of the proposal at the following issue:

- closes https://github.com/2i2c-org/team-compass/issues/670