### PR TITLE
Update deploy.yml with write content permission

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ jobs:
   deploy:
     name: Check links and deploy on main 
     runs-on: ubuntu-18.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The deployment is currently not working (several action failures): https://github.com/2i2c-org/2i2c-org.github.io/actions/workflows/deploy.yml

I also raised this point in https://github.com/2i2c-org/2i2c-org.github.io/pull/147#issuecomment-1453740552

UI workaround reported here is not working (I can't set it up): https://github.com/actions/checkout/issues/417#issuecomment-1123595641

After some more investigation, let's try setting up write permissions in content to see if that fixes it.
Ref: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-first-deployment-with-github_token.


