### PR TITLE
Partnerships reorg

### DIFF
--- a/content/authors/james-munroe/_index.md
+++ b/content/authors/james-munroe/_index.md
@@ -10,7 +10,7 @@ authors:
 superuser: false
 
 # Role/position (e.g., Professor of Artificial Intelligence)
-role: Product and Community Lead
+role: Community Success Manager
 
 # Organizations/Affiliations
 organizations:
@@ -44,7 +44,7 @@ social:
 # Organizational groups that you belong to (for People widget)
 #   Set this to `[]` or comment out if you are not using People widget.
 user_groups:
-- Community Guidance and Partnerships Team
+- Partnerships Team
 ---
 
 James is Product and Community Lead for 2i2c. Coming from a background as an associate professor in the Department of Physics and Physical Oceanography at [Memorial University of Newfoundland](https://mun.ca), he is a strong advocate for enabling scientists and students to be efficient and effective in their computational workflows. Building on previous work in big data oceanography with links to the [Pangeo](https://pangeo.io/) project, [COSIMA](http://cosima.org.au/): Consortium for Ocean-Sea Ice Modelling in Australia, and [CIOOS](https://cioos.ca/): Canadian Integrated Ocean Observing System, James wants to bring the strength of the Jupyter ecosystem to users across a broad range of educational and research domains.

--- a/content/authors/jim-colliander/_index.md
+++ b/content/authors/jim-colliander/_index.md
@@ -55,7 +55,7 @@ email: "colliand@2i2c.org"
 user_groups:
 - Founders
 - Steering Council
-- Community Guidance and Partnerships Team
+- Partnerships Team
 ---
 
 Jim is a 2i2c Co-Founder. He is a Professor of [Mathematics at the University of British Columbia](https://www.math.ubc.ca) and previously served (2016-2021) as the Director of The Pacific Institute for the Mathematical Sciences (PIMS). While at PIMS and using infrastructure from Compute Canada, he helped create a [national-scale JupyterHub service called Syzygy](https://blog.jupyter.org/national-scale-interactive-computing-2c104455e062). He co-founded [Callysto](https://callysto.ca), a collaboration between PIMS and Cybera. Callysto develops open education resources and training programs for students and teachers in grades 5-12 leveraging cloud-hosted interactive computing. Colliander also co-found [Crowdmark](https://crowdmark.com), an education technology company based in Toronto that provides workflows and AI-based improvements to education assessment. 

--- a/content/organization/faces.md
+++ b/content/organization/faces.md
@@ -7,7 +7,7 @@ weight = 20
 [content]
   # Choose which groups/teams of users to display.
   #   Edit `user_groups` in each user's profile to add them to one or more of these groups.
-  user_groups = ["Open Engineering Team", "Community Guidance and Partnerships Team", "Executive Director", "Steering Council"]
+  user_groups = ["Open Engineering Team", "Partnerships Team", "Executive Director", "Steering Council"]
 
 [design]
   # Show user's social networking links? (true/false)


### PR DESCRIPTION
This is a small update to reflect recent re-org changes in 2i2c. Community Guidance and Partnerships are now a single team called Partnerships. We also renamed "Product and Community Lead" to "Community Success Manager".