### PR TITLE
Blog post Q3 2023

### DIFF
--- a/content/blog/2023/2023-q3-update/index.md
+++ b/content/blog/2023/2023-q3-update/index.md
@@ -1,0 +1,131 @@
+---
+title: "Community update Q3 2023: Service growth and growing pains"
+subtitle: ""
+summary: ""
+authors: ["Chris Holdgraf"]
+tags: []
+categories: ["updates"]
+date: 2023-10-31
+featured: false
+draft: false
+---
+
+It's been two quarters since our last major update - this isn't quite as frequent as we're hoping to post updates from our team, but we're making adjustments to have more regular communication for reasons that will hopefully be a bit clearer below!
+In that time, we've been hard at work serving and growing our interactive computing service, as well as doing some introspection as a team and identifying major next steps moving forward.
+More on that in the following sections, but first a short service update.
+
+## How has our service evolved over the past few months?
+
+### New partnerships and service growth
+
+Our service has grown several new partner communities over the last two quarters. A few notable communities are [the NASA VEDA project](https://nasa-veda.2i2c.cloud/), a [team at the Smithsonian](https://smithsonian.2i2c.cloud/), [a team at NCAR](https://ncar-cisl.2i2c.cloud/), and the [U.S. Greenhouse Gases Center](https://hub.ghg.center/). We are running about **71 hubs across 24 clusters, with about 4000 weekly users **([more usage stats here](https://2i2c.org/kpis/cloud/)).
+
+We also began operations on a major collaboration to serve communities in Latin America and Africa, called [the Catalyst Project](https://zenodo.org/records/7025288).
+This team met together for the first time in April, and we've been laying a foundation for service growth in the first several months.
+We are just onboarding our first communities and hope to grow that service in the coming year.
+
+Finally, we've been fortunate to receive some grants around creating content and designing workflows that utilize cloud infrastructure. For example, a [NASA TOPS grant](https://nasa.github.io/Transform-to-Open-Science/open-science-101/) and an upcoming collaboration with [Project Pythia](https://projectpythia.org/) around geospatial workflows.
+
+### Financial picture
+
+At this point, we're **recovering roughly 40% of our operating costs** through recurring fees of our managed hub service (making up the remainder in development contracts and grants), and **we've currently got around 2 years of runway**.
+
+Both of these will be lowered soon, however, because we've about to hire for several more positions.
+Improvements to our product model will allow us to estimate and recovery our service costs more effectively, but we also intend to raise some funds next year to support our efforts in making our service more robust, sustainable, and valuable to communities.
+
+It's always difficult to strike a proper balance of team (and cost) growth against the financial buffer needed to assure your partners you'll stick around, but we're confident that the new hires described below will serve critical needs for our team and mission.
+
+For more context on why and how we're trying to make up that capacity, read on...
+
+## How service growth can lead to team stress
+
+Over the past year we've had a slow-but-steady stream of new communities interested in working with 2i2c for managing cloud infrastructure for interactive computing.
+We've taken a "let's make it work somehow" approach to all of our community partnerships thus far, with the idea that we must use these partnerships to learn what communities want and identify common patterns.
+
+This is exciting, and we're fortunate to see the interest and growth in our service.
+It suggests to us that something about our model is fundamentally right.
+Communities really love the [Right to Replicate](https://2i2c.org/right-to-replicate), and our participatory service model based around upstream contributions, transparency, and shared responsibility is attractive to many in research and education.
+
+However, each new community is also a new set of stresses on the technical and social infrastructure of our team.
+Without the capacity to manage the demands of the service, you run the risk of over-extending, and in a worst case scenario, burning out, your team.
+
+This became clear in our first in-person team meeting last May.
+At that meeting, we realized that many on the team were spending too much of their time "reacting" to demands from the service.
+We also learned that the scope and complexity of our various workstreams had gotten to a size where our informal team structures of work prioritization were no longer adequate.
+
+## Growing the complexity of our team to match the complexity of our service
+
+So, for the past several months we've been working on a plan to evolve 2i2c's team structure in order to more effectively manage the complexity of our service, and balance long- and short-term thinking.
+
+This began with an organizational audit carried out by [makeadifference.digital](https://www.makeadifference.digital/), a consulting group that focusese on tech-for-good and non-profit products and services.
+They conducted interviews with everybody on the team, and concluded that we have a few key functions missing that were creating or compounding the stresses people felt.
+
+We're looking into ways that we can make more of this work public, but in the meantime here is an overview of some highlights:
+
+### We need a dedicated product functionality
+
+First, we realized that we have a number of new "signals" pushing our service in many different directions.
+Some are external - from communities we work with or from funders. Some are internal - from different team member visions of where work is needed.
+After growing our service and our team, there are now too many perspectives and voices to balance in a purely unstructured and organic way.
+
+So we're creating a **dedicated "product function" within 2i2c**.
+Its goal will be to serve as an integrator across the many stakeholders that are interested in 2i2c's service, and synthesize a collective product strategy and system of prioritization to move the organization forward.
+They'll help 2i2c grow a culture of iteration and decisions that are driven by the needs of our community partners and users.
+
+We're [hiring a Product Lead](https://2i2c.org/jobs/2023/product-lead/) to kick off this effort.
+If you think you'd be interested in this role, please consider applying!
+
+### We need a more structured system of work and execution
+
+Next, we realized that there are many different workstreams we must balance simultaneously.
+There are new communities to be onboarded, infrastructure bugs to be fixed, questions to be answered, and strategic priorities to improve the service.
+Expecting each team member to individually find the right balance between all of these is increasingly unrealistic.
+We need capacity to oversee this system of work and bring some structure to it.
+
+So, we're creating a **Deliver Manager role** to oversee the system of work that our engineering team uses for its planning and execution.
+In addition, this role will serve at an organization-wide capacity as an **interrim Chief of Staff**.
+This will allow them to improve and standardize practices organization-wide, and coordinate major projects that span our team.
+
+You can find a [job posting for a Delivery Manager / interrim Chief of Staff](https://2i2c.org/jobs/2023/delivery-manager/) role.
+If you think you'd be interested, please apply!
+
+### We need more capacity to support our team and its individuals
+
+In addition to moving forward our workstreams, we also have a unique challenge in team support and dynamics.
+2i2c is a small team, it is also distributed across 10 time zones!
+This adds a lot of extra challenge in getting the team to communicate with one another, support one another as individuals, and learn and grow as a team.
+We believe that it's critical to support one another, and to have systems in 2i2c that recognize these challenges in distributed collaboration to design around them.
+
+So, we're exploring how to create a **"People Operations" function within 2i2c** that can dedicate their time to supporting 2i2c's team as a group as individuals.
+This might mean defining creative ways for team-building, creating mechanisms to surface where team members are struggling or need support, and growing best-practices in inclusive asynchronous team culture.
+
+We're in the process of designing this role, and hope to have it out in the coming months!
+
+### We need more engineering capacity
+
+Finally, we also realized we need more cloud engineering capacity on our team, particularly in a timezone that overlaps with the American continents.
+This will give our team a bit more breathing room to balance reactive and project-based work, and have more capacity to focus on personal growth and learning.
+
+You can find our [Open Source Infrastructure Engineer](https://2i2c.org/jobs/2023/23qq4-open-source-infrastructure-engineer/) job post here if you're interested.
+
+## What's up next for our team?
+
+Finally, we've also adopted a new quarterly planning system to align our team around key goals that deserve focused attention in each quarter.
+This will let us be more intentional about considering our work in the context of 2i2c's broader opportunities and challenges.
+
+For the final quarter of 2023, we're focusing on these key goals:
+
+* **Begin to standardize and refine our product offering**.
+  In advance of our Product Lead role, we are doing a bit of work to more precisely describe and structure our _current_ service offering.
+  Our goal is to lay a foundation that our upcoming Product Lead can then use to learn about 2i2c's product and make progress more quickly.
+* **Pay down technical debt**.
+  Our engineering team is going to focus on streamlining their operations and reducing toil, in order to reduce the number of "unexpected distractions" that come with inefficient infrastructure and processes.
+  It will also make the service more reliable and transparent for our communities.
+* **Build foundational resources for hub champions to support their community.**
+  Our Partnerships team will lead an effort to build basic infrastructure and content that communities can use to create their own knowledge bases around hubs. This will be ongoing work so the goal here is to create a foundation to build upon in the future.
+
+We hope that this has been an informative update from our team, and we appreciate everybody's input and collaboration over the past few months.
+We think that the tensions described in this post are healthy - they're reflective of an organization that is growing and reaching organizational milestones.
+We're excited to tackle them and to continue growing our impact and partnerships.
+
+{{% about-us %}}

--- a/content/blog/2023/2023-q3-update/index.md
+++ b/content/blog/2023/2023-q3-update/index.md
@@ -31,7 +31,7 @@ Finally, we've been fortunate to receive some grants around creating content and
 At this point, we're **recovering roughly 40% of our operating costs** through recurring fees of our managed hub service (making up the remainder in development contracts and grants), and **we've currently got around 2 years of runway**.
 
 Both of these will be lowered soon, however, because we've about to hire for several more positions.
-Improvements to our product model will allow us to estimate and recovery our service costs more effectively, but we also intend to raise some funds next year to support our efforts in making our service more robust, sustainable, and valuable to communities.
+Improvements to our product model will allow us to estimate and recover our service costs more effectively, but we also intend to raise some funds next year to support our efforts in making our service more robust, sustainable, and valuable to communities.
 
 It's always difficult to strike a proper balance of team (and cost) growth against the financial buffer needed to assure your partners you'll stick around, but we're confident that the new hires described below will serve critical needs for our team and mission.
 
@@ -57,7 +57,7 @@ We also learned that the scope and complexity of our various workstreams had got
 
 So, for the past several months we've been working on a plan to evolve 2i2c's team structure in order to more effectively manage the complexity of our service, and balance long- and short-term thinking.
 
-This began with an organizational audit carried out by [makeadifference.digital](https://www.makeadifference.digital/), a consulting group that focusese on tech-for-good and non-profit products and services.
+This began with an organizational audit carried out by [makeadifference.digital](https://www.makeadifference.digital/), a consulting group that focuses on tech-for-good and non-profit products and services.
 They conducted interviews with everybody on the team, and concluded that we have a few key functions missing that were creating or compounding the stresses people felt.
 
 We're looking into ways that we can make more of this work public, but in the meantime here is an overview of some highlights:
@@ -82,8 +82,8 @@ There are new communities to be onboarded, infrastructure bugs to be fixed, ques
 Expecting each team member to individually find the right balance between all of these is increasingly unrealistic.
 We need capacity to oversee this system of work and bring some structure to it.
 
-So, we're creating a **Deliver Manager role** to oversee the system of work that our engineering team uses for its planning and execution.
-In addition, this role will serve at an organization-wide capacity as an **interrim Chief of Staff**.
+So, we're creating a **Delivery Manager role** to oversee the system of work that our engineering team uses for its planning and execution.
+In addition, this role will serve at an organization-wide capacity as an **interim Chief of Staff**.
 This will allow them to improve and standardize practices organization-wide, and coordinate major projects that span our team.
 
 You can find a [job posting for a Delivery Manager / interrim Chief of Staff](https://2i2c.org/jobs/2023/delivery-manager/) role.

--- a/content/blog/2023/2023-q3-update/index.md
+++ b/content/blog/2023/2023-q3-update/index.md
@@ -18,7 +18,7 @@ More on that in the following sections, but first a short service update.
 
 ### New partnerships and service growth
 
-Our service has grown several new partner communities over the last two quarters. A few notable communities are [the NASA VEDA project](https://nasa-veda.2i2c.cloud/), a [team at the Smithsonian](https://smithsonian.2i2c.cloud/), [a team at NCAR](https://ncar-cisl.2i2c.cloud/), and the [U.S. Greenhouse Gases Center](https://hub.ghg.center/). We are running about **71 hubs across 24 clusters, with about 4000 weekly users **([more usage stats here](https://2i2c.org/kpis/cloud/)).
+Our service has grown several new partner communities over the last two quarters. A few notable communities are [the NASA VEDA project](https://nasa-veda.2i2c.cloud/), a [team at the Smithsonian](https://smithsonian.2i2c.cloud/), [a team at NCAR](https://ncar-cisl.2i2c.cloud/), and the [U.S. Greenhouse Gases Center](https://hub.ghg.center/). We are running about **71 hubs across 24 clusters, with about 4000 weekly users** ([more usage stats here](https://2i2c.org/kpis/cloud/)).
 
 We also began operations on a major collaboration to serve communities in Latin America and Africa, called [the Catalyst Project](https://zenodo.org/records/7025288).
 This team met together for the first time in April, and we've been laying a foundation for service growth in the first several months.
@@ -30,7 +30,7 @@ Finally, we've been fortunate to receive some grants around creating content and
 
 At this point, we're **recovering roughly 40% of our operating costs** through recurring fees of our managed hub service (making up the remainder in development contracts and grants), and **we've currently got around 2 years of runway**.
 
-Both of these will be lowered soon, however, because we've about to hire for several more positions.
+However, both of these will be lowered soon because we are about to hire for several more positions.
 Improvements to our product model will allow us to estimate and recover our service costs more effectively, but we also intend to raise some funds next year to support our efforts in making our service more robust, sustainable, and valuable to communities.
 
 It's always difficult to strike a proper balance of team (and cost) growth against the financial buffer needed to assure your partners you'll stick around, but we're confident that the new hires described below will serve critical needs for our team and mission.
@@ -47,7 +47,7 @@ It suggests to us that something about our model is fundamentally right.
 Communities really love the [Right to Replicate](https://2i2c.org/right-to-replicate), and our participatory service model based around upstream contributions, transparency, and shared responsibility is attractive to many in research and education.
 
 However, each new community is also a new set of stresses on the technical and social infrastructure of our team.
-Without the capacity to manage the demands of the service, you run the risk of over-extending, and in a worst case scenario, burning out, your team.
+Without the capacity to manage the demands of the service, you run the risk of over-extending -- and in a worst case scenario, burning out -- your team.
 
 This became clear in our first in-person team meeting last May.
 At that meeting, we realized that many on the team were spending too much of their time "reacting" to demands from the service.
@@ -60,13 +60,13 @@ So, for the past several months we've been working on a plan to evolve 2i2c's te
 This began with an organizational audit carried out by [makeadifference.digital](https://www.makeadifference.digital/), a consulting group that focuses on tech-for-good and non-profit products and services.
 They conducted interviews with everybody on the team, and concluded that we have a few key functions missing that were creating or compounding the stresses people felt.
 
-We're looking into ways that we can make more of this work public, but in the meantime here is an overview of some highlights:
+We hope to make some of their key findings public soon, and in the meantime here is an overview of some highlights:
 
 ### We need a dedicated product functionality
 
 First, we realized that we have a number of new "signals" pushing our service in many different directions.
 Some are external - from communities we work with or from funders. Some are internal - from different team member visions of where work is needed.
-After growing our service and our team, there are now too many perspectives and voices to balance in a purely unstructured and organic way.
+After growing our service and our team, there are now too many perspectives and voices to balance in an unstructured and purely organic way.
 
 So we're creating a **dedicated "product function" within 2i2c**.
 Its goal will be to serve as an integrator across the many stakeholders that are interested in 2i2c's service, and synthesize a collective product strategy and system of prioritization to move the organization forward.

--- a/layouts/partials/hooks/head-start/custom.html
+++ b/layouts/partials/hooks/head-start/custom.html
@@ -1,3 +1,3 @@
 <!-- Load Google fonts to use throughout -->
 <link rel="preconnect" href="https://fonts.gstatic.com">
-<link href="https://fonts.googleapis.com/css2?family=Poppins&family=Work+Sans" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&family=Work+Sans:wght@400;700" rel="stylesheet">


### PR DESCRIPTION
This is a brief update for Q3 2023. It's a bit later than intended but I wanted to get all the near-term job postings up before getting this out.

It describes some of the stuff our team has identified and been working through over the past few months, and describes some of the major organizational shifts we're looking to make to adjust.