### PR TITLE
Move the featured image partial to new path

### DIFF
--- a/layouts/partials/blox-core/functions/get_featured_image.html
+++ b/layouts/partials/blox-core/functions/get_featured_image.html
@@ -1,7 +1,7 @@
 {{/*
   Modification of the Minimal theme function in order to add social media-generated cards.
   
-  ref: https://github.com/HugoBlox/hugo-blox-builder/blob/549d2cd12615c425ee962ce93fbe8b21094f1b0f/modules/wowchemy-core/layouts/partials/functions/get_featured_image.html#L4
+  ref: https://github.com/HugoBlox/hugo-blox-builder/blob/7d5cbf3ce7a1488170b17f412c5689aed46e742f/modules/blox-core/layouts/partials/blox-core/functions/get_featured_image.html
 */}}
 
 {{/* Function to retrieve the featured image */}}

--- a/layouts/partials/blox-core/functions/get_featured_image.html
+++ b/layouts/partials/blox-core/functions/get_featured_image.html
@@ -14,7 +14,7 @@
       2. Search for a file `.Params.image.filename` in the post directory
       3. Search for a file `.Params.image.filename` in the `assets/media/` directory
 */}}
-
+fsdagsdf
 {{/* Search for an image "*featured*" in post folder */}}
 {{ $resource := (.Resources.ByType "image").GetMatch "*featured*" }}
 {{ if eq $resource nil }}


### PR DESCRIPTION
The theme we use moved the partial function used to generate social media images, so this just moves our over-ride function to the corresponding new location. This un-breaks social media preview generation.