### PR TITLE
Render url with .md to correct link

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -5,4 +5,6 @@
 {{ $title = replace $title "https://github.com/" "" }}
 {{ $title = replace $title "/issues/" "#" }}
 {{ $title = replace $title "/pull/" "#" }}
+
+// This is a custom link resolver that resolves both internal and external links, thanks to @cmd-ntrf for the helpful fix.
 <a {{ if strings.HasPrefix .Destination "http" }}href="{{ .Destination | safeURL }}" target="_blank" rel="noopener" {{ else }} href="{{ (.Page.GetPage .Destination).RelPermalink | safeURL }}" {{ end }} {{ with .Title}} title="{{ . }}"{{ end }}>{{ $title | safeHTML }}</a>

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -5,4 +5,4 @@
 {{ $title = replace $title "https://github.com/" "" }}
 {{ $title = replace $title "/issues/" "#" }}
 {{ $title = replace $title "/pull/" "#" }}
-<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="noopener"{{ end }}>{{ $title | safeHTML }}</a>
+<a href="{{ (.Page.GetPage .Destination).RelPermalink | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="noopener"{{ end }}>{{ $title | safeHTML }}</a>

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -5,4 +5,4 @@
 {{ $title = replace $title "https://github.com/" "" }}
 {{ $title = replace $title "/issues/" "#" }}
 {{ $title = replace $title "/pull/" "#" }}
-<a href="{{ (.Page.GetPage .Destination).RelPermalink | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="noopener"{{ end }}>{{ $title | safeHTML }}</a>
+<a {{ if strings.HasPrefix .Destination "http" }}href="{{ .Destination | safeURL }}" target="_blank" rel="noopener" {{ else }} href="{{ (.Page.GetPage .Destination).RelPermalink | safeURL }}" {{ end }} {{ with .Title}} title="{{ . }}"{{ end }}>{{ $title | safeHTML }}</a>


### PR DESCRIPTION
Links referring to other 2i2c blog posts are currently returning a 404 because they are improperly rendered.

Example of two links in [Improvements to our team's planning and delivery](https://2i2c.org/blog/2024/delivery-improvements/)

```
<a href="../../2023/organizational-report/index.md">our 2023 report of organizational strengths and weaknesses</a>
```
 
```
<a href="../../2023/organizational-report/index.md">released a report describing our organizational strengths and weaknesses</a>
```

I am not a Hugo expert, so I had to Google a solution, which I have included in this PR.

Also note that the GitHub link checker workflow appears to miss these broken links. I have yet found why as lychee was acting weirdly on my laptop.