### PR TITLE
Fix several incorrect links to md files

### DIFF
--- a/content/blog/2022/q3-update/index.md
+++ b/content/blog/2022/q3-update/index.md
@@ -61,7 +61,7 @@ These are large-scale organizational and strategic efforts that impact all of 2i
 
 **We grew our team**: We've hired two new team members to lead new major efforts with 2i2c. [**James Munroe**](https://2i2c.org/author/james-munroe/) will lead efforts around _community guidance and product design_, and [**Jim Colliander**](https://2i2c.org/author/jim-colliander/) will lead efforts around _partnerships and sustainability_. We also [updated our Hiring and Candidate Search documentation](https://github.com/2i2c-org/team-compass/issues/436) in the process.
 
-**We're refining our strategy**: We've begun a process of revisiting and refining our strategy after a year of major operations, see [our strategic update blog post for more information](../strategic-update/index.md).
+**We're refining our strategy**: We've begun a process of revisiting and refining our strategy after a year of major operations, see [our strategic update blog post for more information](../strategic-update/).
 
 **We completed the [CSCCE](https://cscce.org) community management training**. Two of our team members (James and Sarah) both completed a several-week community management course that was offered in partnership with [CZI](https://chanzuckerberg.org).
 

--- a/content/blog/2023/cilogon-integration/index.md
+++ b/content/blog/2023/cilogon-integration/index.md
@@ -49,4 +49,4 @@ Thanks to the 2i2c - CILogon partnership, during this past year we were able to 
 
 We are now happy to announce that the 2i2c - CILogon partnership has been expanded to another year!
 
-**Acknowledgements**: The upstream [`jupyterhub-oauthenticator`](https://oauthenticator.readthedocs.io/en/latest) project mentioned in this post as being used at 2i2c is a JupyterHub package, kindly developed and maintained by the [JupyterHub community](https://discourse.jupyter.org/c/jupyterhub/) and the 2i2c integration described was developed by [the 2i2c engineering team](/organization/team.md). Also, this post was edited by [Jim Basney](https://jbasney.net/).
+**Acknowledgements**: The upstream [`jupyterhub-oauthenticator`](https://oauthenticator.readthedocs.io/en/latest) project mentioned in this post as being used at 2i2c is a JupyterHub package, kindly developed and maintained by the [JupyterHub community](https://discourse.jupyter.org/c/jupyterhub/) and the 2i2c integration described was developed by [the 2i2c engineering team](../../../organization/). Also, this post was edited by [Jim Basney](https://jbasney.net/).

--- a/content/blog/2024/delivery-improvements/index.md
+++ b/content/blog/2024/delivery-improvements/index.md
@@ -9,15 +9,15 @@ featured: false
 draft: false
 ---
 
-_This is a follow-up to [our 2023 report of organizational strengths and weaknesses](../../2023/organizational-report/index.md), describing some improvements we've made on our team's coordination and delivery_.
+_This is a follow-up to [our 2023 report of organizational strengths and weaknesses](../../2023/organizational-report), describing some improvements we've made on our team's coordination and delivery_.
 
-In 2023, we [released a report describing our organizational strengths and weaknesses](../../2023/organizational-report/index.md).
+In 2023, we [released a report describing our organizational strengths and weaknesses](../../2023/organizational-report).
 This uncovered a key challenge for our team: **improving our coordination and delivery**.
 Over the previous two years, our service had grown significantly in its scope and complexity.
 We were working on more than 7 active grants and were serving more than 70 active communities with around 7,000 monthly active users.
 
 This was taxing our small team, and we found ourselves struggling to efficiently deliver on our work.
-For example, a [collaboration with GESIS to bring image building functionality to JupyterHub](../../2024/jupyterhub-binderhub-gesis/index.md) took longer than we wished, and we felt that our planning and execution was not transparent enough to their team. In addition, in [a collaboration to serve communities in Latin America and Africa](https://catalystproject.cloud) we felt that 2i2c was not responsive enough to onboarding and deploying infrastructure for new communities.
+For example, a [collaboration with GESIS to bring image building functionality to JupyterHub](../../2024/jupyterhub-binderhub-gesis) took longer than we wished, and we felt that our planning and execution was not transparent enough to their team. In addition, in [a collaboration to serve communities in Latin America and Africa](https://catalystproject.cloud) we felt that 2i2c was not responsive enough to onboarding and deploying infrastructure for new communities.
 
 ## Steps we've taken to improve delivery
 

--- a/content/jobs/2023/product-operations-lead.md
+++ b/content/jobs/2023/product-operations-lead.md
@@ -11,7 +11,7 @@ open = false
 show_date = true
 +++
 
-Please see the [Product Lead page](./product-lead.md).
+Please see the [Product Lead page](./product-lead).
 
 <meta http-equiv="refresh" content="0; url=../product-lead/" />
 


### PR DESCRIPTION
This is an alternative fix to the PR below. It changes some links that were directly to `.md` files but should instead have been to the parent folder because Hugo linking is weird.

- https://github.com/2i2c-org/2i2c-org.github.io/pull/246

