### PR TITLE
Fix link resolver comment

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -6,5 +6,6 @@
 {{ $title = replace $title "/issues/" "#" }}
 {{ $title = replace $title "/pull/" "#" }}
 
-// This is a custom link resolver that resolves both internal and external links, thanks to @cmd-ntrf for the helpful fix.
+{{/* This is a custom link resolver that resolves both internal and external links, thanks to @cmd-ntrf for the helpful fix. */}}
+
 <a {{ if strings.HasPrefix .Destination "http" }}href="{{ .Destination | safeURL }}" target="_blank" rel="noopener" {{ else }} href="{{ (.Page.GetPage .Destination).RelPermalink | safeURL }}" {{ end }} {{ with .Title}} title="{{ . }}"{{ end }}>{{ $title | safeHTML }}</a>


### PR DESCRIPTION
Fixes a bug where our link resolver used the wrong comment syntax and so was showing up on all links!