### PR TITLE
Fix broken link to updates category in homepage

### DIFF
--- a/layouts/shortcodes/about-hubs.html
+++ b/layouts/shortcodes/about-hubs.html
@@ -1,5 +1,5 @@
 - [Our Team Compass](https://compass.2i2c.org) contains all of 2i2c's organizational strategy, policy, and team practices.
-- [Our updates blog series](/category/updates) provides all major organizational updates for our community.
+- [Our updates blog series](https://2i2c.org/category/updates/) provides all major organizational updates for our community.
 - [Our Service Level Objectives](https://docs.2i2c.org/about/service/service-objectives.html) describes our day-to-day goals running the service.
 - [Our Shared Responsibility Model](https://docs.2i2c.org/about/service/index.html) describes how we collaborate with communities in this hub service.
 - [Our Infrastructure Guide](https://infrastructure.2i2c.org/) describes all of our cloud infrastructure and engineering practices, with links to our codebase.


### PR DESCRIPTION
Was missing header part of the URL. Not sure if there's a cleaner fix, not a Hugo expert at all...