### PR TITLE
fix: drop MyST-engine previews from 2i2c post

### DIFF
--- a/content/blog/2024/jupyter-book-2/index.md
+++ b/content/blog/2024/jupyter-book-2/index.md
@@ -54,7 +54,7 @@ The Jupyter Book 2 project is a complete re-write of Jupyter Book. We expect the
 
 ### Rich Hover Previews
 
-Try hovering over [this tooltip about tooltips!](https://en.wikipedia.org/wiki/Tooltip). The new MyST book and article themes provide useful hover previews for links to other MyST content, Wikipedia, GitHub issues, and many more.
+The new MyST book and article themes provide useful hover previews for links to other MyST content, Wikipedia, GitHub issues, and many more.
 
 <video width="100%" autoplay>
     <source src="https://github.com/jupyter-book/blog/raw/refs/heads/main/media/hover-previews.mp4" type="video/mp4">
@@ -64,7 +64,7 @@ Try hovering over [this tooltip about tooltips!](https://en.wikipedia.org/wiki/T
 
 Content from other websites built with the MyST engine can be embedded in your own sites and PDFs:
 
-![Image of a mountain range.](https://cdn.curvenote.com/0192bff5-9c9d-722f-92bf-e702aa8e1f46/public/c8830546aa82907becb6cd46c414a80c.webp "Cross-referenced content can easily be embedded and re-captioned into other pages and projects, such as this figure to <xref:guide#mylabel>.")
+![Image of a mountain range.](https://cdn.curvenote.com/0192bff5-9c9d-722f-92bf-e702aa8e1f46/public/c8830546aa82907becb6cd46c414a80c.webp "Cross-referenced content can easily be embedded and re-captioned into other pages and projects, such as this figure to <https://mystmd.org/guide/embed#mylabel>.")
 
 ### Simple Instant Search
 


### PR DESCRIPTION
@jnywong are you OK with me editing the cross-post content to drop reference to in-blog-post previews that don't function on our blog? (e.g. hover-previews)