### PR TITLE
Update 2i2c.html

### DIFF
--- a/layouts/partials/components/footers/2i2c.html
+++ b/layouts/partials/components/footers/2i2c.html
@@ -13,9 +13,9 @@
   <div class="col-6 col-md-4">
     <h5>Technical</h5>
     <ul class="nav flex-column">
-      <li class="nav-item mb-2"><a href="#" class="nav-link p-0 text-muted">GitHub</a></li>
-      <li class="nav-item mb-2"><a href="#" class="nav-link p-0 text-muted">Documentation</a></li>
-      <li class="nav-item mb-2"><a href="#" class="nav-link p-0 text-muted">Pricing</a></li>
+      <li class="nav-item mb-2"><a href="https://github.com/2i2c-org" class="nav-link p-0 text-muted">GitHub</a></li>
+      <li class="nav-item mb-2"><a href="https://docs.2i2c.org/" class="nav-link p-0 text-muted">Documentation</a></li>
+      <li class="nav-item mb-2"><a href="https://docs.2i2c.org/about/service/options/" class="nav-link p-0 text-muted">Pricing</a></li>
     </ul>
   </div>
 


### PR DESCRIPTION
Fixes broken footer links (#348) . Haven't blamed to see if these were ever defined. 