### PR TITLE
Fix our blog archive pages and spell out 2i2c's org name in a few places

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -43,7 +43,7 @@
 
   [[main]]
   parent = "about"
-  name = "Our team"
+  name = "Our organization and team"
   url = "organization/"
   weight = 15
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -47,7 +47,7 @@ sections:
 
         {{< servicetech >}}
 
-        2i2c's [community hub platform and consultancy services](/platform) ensure your community makes the best use of open infrastructure for interactive computing in the cloud.
+        2i2c stands for **the International Interactive Computing Collaboration**. Our [community hub platform and consultancy services](/platform) ensure your community makes the best use of open infrastructure for interactive computing in the cloud.
 
         We serve **over 90 communities across the globe** with **over 7000 active users** dedicated to creating and sharing knowledge. See [our community impact stories](/communities) for inspiration.
 

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,32 +1,17 @@
 ---
-title: Blog posts
-type: landing
-sections:
-  - block: collection
-    id: posts
-    content:
-      title: Recent Posts
-      subtitle: "[Organization Updates](/categories/organization) | [Service Updates](/categories/service) | [Community Impact](/categories/impact)"
-      count: 10
-      filters:
-        folders:
-          - blog
-        author: ""
-        category: ""
-        tag: ""
-        publication_type: ""
-        featured_only: false
-        exclude_featured: false
-        exclude_future: false
-        exclude_past: false
-      offset: 0
-      sort_by: Date
-      sort_ascending: false
-      archive:
-        enable: true
-        text: See older blog posts
-        link: blog/page/2
-    design:
-      view: compact
-      columns: "1"  
+title: Recent blog posts
+---
+
+<style>
+.category-labels, .page-body h1:first-of-type {
+  text-align: center;
+}
+</style>
+
+<div class="category-labels">
+
+[Organization Updates](/categories/organization) | [Service Updates](/categories/service) | [Community Impact](/categories/impact)
+
+</div>
+
 ---

--- a/content/organization/about.md
+++ b/content/organization/about.md
@@ -8,6 +8,7 @@ title = "Our organization and team"
   columns = "1"
 +++
 
+2i2c stands for **the International Interactive Computing Collaboration**.
 We are a non-profit, fiscally-sponsored project of [Code for Science and Society](https://codeforscience.org), a US 501(c)(3) public charity.
 
 We are a distributed team spread across South America, Western and Eastern Europe, and North America. We have a combination of experience in cloud engineering and open source, research and education, and open communities. Our Steering Council provides strategic guidance and oversight to our team.


### PR DESCRIPTION
- closes https://github.com/2i2c-org/2i2c-org.github.io/issues/392