### PR TITLE
Add quarterly community update posts

### DIFF
--- a/content/authors/chris-holdgraf/_index.md
+++ b/content/authors/chris-holdgraf/_index.md
@@ -10,7 +10,7 @@ authors:
 superuser: true
 
 # Role/position (e.g., Professor of Artificial Intelligence)
-role: Executive Director / Co-lead of Business Development
+role: Executive Director
 
 # Organizations/Affiliations
 organizations:

--- a/content/authors/jim-colliander/_index.md
+++ b/content/authors/jim-colliander/_index.md
@@ -10,7 +10,7 @@ authors:
 superuser: true
 
 # Role/position (e.g., Professor of Artificial Intelligence)
-role: Senior Account Executive / Co-lead of Business Development
+role: Business Development Lead
 
 # Organizations/Affiliations
 organizations:

--- a/content/blog/2025/q1-product-highlights/index.md
+++ b/content/blog/2025/q1-product-highlights/index.md
@@ -1,0 +1,71 @@
+---
+title: "Product highlights \- Q2 2025"
+authors: ["Chris Holdgraf", "Giuliano Maccioci"]
+categories: [service]
+date: 2025-04-16
+---
+
+These describe the major service improvements that we rolled out in Q1 2025\. See this [blog post describing our product enhancement goals in Q1 2025](https://2i2c.org/blog/2025/q1-product-goals/) for the targets we intended to hit this quarter. Below is a brief description of what we accomplished.
+
+## User storage quotas*
+
+A key part of 2i2c’s service is **making the cloud safe to try**. One of the biggest concerns from our communities is that their cloud costs will be unexpectedly high. This quarter we decided to make cloud storage a bit safer. Storage can get expensive, especially when a user accidentally downloads a particularly large file \- they may not even realize that doing so incurs an extra cost. For this reason, we added the ability to limit user storage on JupyterHubs:
+
+[Enforcing per-user storage quotas with \`jupyterhub-home-nfs\`](https://2i2c.org/blog/2025/per-user-storage-quota/)
+
+We initially deployed this feature on our AWS hubs, and followed up by deploying it on GCP hubs as well. Any community with a hub on AWS and GCP now has the ability to limit the storage that their users receive, greatly increasing our communities’ control over their costs.  
+   
+[Enforcing per-user storage quotas now available on GCP](https://2i2c.org/blog/2025/per-user-storage-quota-gcp/)
+
+***Thanks to** [DevSeed](https://developmentseed.org/) for collaboration on this work, in addition to the [NASA VEDA project](https://www.earthdata.nasa.gov/data/tools/veda) for funding this effort.*
+
+## Automated backups for GCP hubs
+
+Another concern communities have is “what happens if something breaks and I lose data?” Cloud providers offer a number of ways to recover from disasters like this, and we did some work enabling this for GCP so that communities have disaster recovery options available to them.
+
+[Announcing backups for GCP-hosted hubs\!](https://2i2c.org/blog/2025/gcp-filestore-backups/)
+
+## Deploying JupyterHub on public infrastructure
+
+Deploying Kubernetes and JupyterHub on publicly-managed infrastructure could be an excellent way to reduce the perceived risk of depending on large tech companies for their key workflows, and potentially reduce costs by using federal infrastructure that can be paid with special grant funding. We built team expertise in deploying and running JupyterHub and BinderHub on JetStream2, and have promising results that we hope to build upon in Q2.
+
+[Open infrastructure for collaborative geoscience with Project Pythia: Learning how to deploy a BinderHub on Jetstream2](https://2i2c.org/blog/2025/jetstream-binderhub/)
+
+***Thanks to** [Jetstream2](https://jetstream-cloud.org/) for an ACCESS allocation, to Julian Pistorius for technical support, to [Project Pythia](https://projectpythia.org/) (NSF award 2324302\) for funding this work, and to [Andrea Zonca](https://www.zonca.dev/posts/2024-12-11-jetstream_kubernetes_magnum) for preliminary work on Kubernetes deployments on Jetstream 2\.*
+
+## Upgrading to the latest JupyterHub
+
+We upgraded all of 2i2c’s community hubs to use JupyterHub 5.0. This brings in a bunch of security improvements, bugfixes, and enhancements. You can find links to the highlights and changelog in our blog post below.
+
+[2i2c hubs now run JupyterHub 5.0](https://2i2c.org/blog/2025/jupyterhub5-upgrade/)
+
+## Reproducible environments for community members
+
+Finally, we did a bit of product brainstorming around enabling communities to bring their environments with them when they publish. We are interested in making it easy to re-use a community’s hub infrastructure to provide the reproducible environments needed for publishing or communicating their work externally. Here’s a brief brainstorm for what this could look like:
+
+[Towards frictionless, portable, and sustainable reproducibility with Binder](https://2i2c.org/blog/2025/frictionless-reproducibility/)
+
+## Improving the UX and flexibility of community documentation with MyST
+
+To provide our communities with quality documentation that sits alongside their Hubs, we have been working on improving MyST to allow for a more flexible and usable document authoring experience, with improvements to landing page layouts, theming, galleries, button layouts, and project launching. We’re aiming to deliver a complete MVP covering our communities’ most requested features by the end of Q2. 
+
+## In case you missed it
+
+Finally, below are a few other blog posts where we’ve documented major impact stories and organizational updates:
+
+**Community impact**
+
+- [Harnessing Marine Open Data Science for Ocean Sustainability in Africa, South Asia and Latin America](https://2i2c.org/blog/2025/hackweek-shoutout/)  
+- [NASA VEDA & 2i2c Update for Q4 2024 (Oct-Dec 2024\)](https://2i2c.org/blog/2025/veda-update-q4-2024/)
+
+**Open Source impact**
+
+- [Chris is joining Project Jupyter's Executive Council](https://2i2c.org/blog/2025/jupyter-executive-council/)  
+- [Simplifying and speeding up Binder builds with BuildKit](https://blog.jupyter.org/simplifying-and-speeding-up-binder-builds-with-buildkit-d44f96582994)  
+- [2i2c joins the mybinder.org federation with a cheaper and faster way to deploy Binderhub](https://2i2c.org/blog/2025/binder-singlenode/)  
+- [Designing for an ecosystem: a case study in cross-project open source contribution](https://2i2c.org/blog/2025/jupyter-book-cors/)
+
+**Organizational updates**
+
+- [Announcing our formal commitment to open technology](https://2i2c.org/blog/2025/community-ownership/)
+

--- a/content/blog/2025/q1-product-highlights/index.md
+++ b/content/blog/2025/q1-product-highlights/index.md
@@ -1,29 +1,29 @@
 ---
-title: "Product highlights \- Q2 2025"
+title: "Our product highlights from Q2 2025"
 authors: ["Chris Holdgraf", "Giuliano Maccioci"]
 categories: [service]
 date: 2025-04-16
 ---
 
-These describe the major service improvements that we rolled out in Q1 2025\. See this [blog post describing our product enhancement goals in Q1 2025](https://2i2c.org/blog/2025/q1-product-goals/) for the targets we intended to hit this quarter. Below is a brief description of what we accomplished.
+_These describe the major service improvements that we rolled out in Q1 2025. See this [blog post describing our product enhancement goals in Q1 2025](../q1-product-goals/index.md) for the targets we intended to hit this quarter. Below is a brief description of what we accomplished._
 
-## User storage quotas*
+## User storage quotas
 
-A key part of 2i2c’s service is **making the cloud safe to try**. One of the biggest concerns from our communities is that their cloud costs will be unexpectedly high. This quarter we decided to make cloud storage a bit safer. Storage can get expensive, especially when a user accidentally downloads a particularly large file \- they may not even realize that doing so incurs an extra cost. For this reason, we added the ability to limit user storage on JupyterHubs:
+A key part of 2i2c’s service is **making the cloud safe to try**. One of the biggest concerns from our communities is that their cloud costs will be unexpectedly high. This quarter we decided to make cloud storage a bit safer. Storage can get expensive, especially when a user accidentally downloads a particularly large file - they may not even realize that doing so incurs an extra cost. For this reason, we added the ability to limit user storage on JupyterHubs:
 
-[Enforcing per-user storage quotas with \`jupyterhub-home-nfs\`](https://2i2c.org/blog/2025/per-user-storage-quota/)
+[Enforcing per-user storage quotas with `jupyterhub-home-nfs`](https://2i2c.org/blog/2025/per-user-storage-quota/)
 
 We initially deployed this feature on our AWS hubs, and followed up by deploying it on GCP hubs as well. Any community with a hub on AWS and GCP now has the ability to limit the storage that their users receive, greatly increasing our communities’ control over their costs.  
    
 [Enforcing per-user storage quotas now available on GCP](https://2i2c.org/blog/2025/per-user-storage-quota-gcp/)
 
-***Thanks to** [DevSeed](https://developmentseed.org/) for collaboration on this work, in addition to the [NASA VEDA project](https://www.earthdata.nasa.gov/data/tools/veda) for funding this effort.*
+_**Thanks to** [DevSeed](https://developmentseed.org/) for collaboration on this work, in addition to the [NASA VEDA project](https://www.earthdata.nasa.gov/data/tools/veda) for funding this effort._
 
 ## Automated backups for GCP hubs
 
 Another concern communities have is “what happens if something breaks and I lose data?” Cloud providers offer a number of ways to recover from disasters like this, and we did some work enabling this for GCP so that communities have disaster recovery options available to them.
 
-[Announcing backups for GCP-hosted hubs\!](https://2i2c.org/blog/2025/gcp-filestore-backups/)
+[Announcing backups for GCP-hosted hubs!](https://2i2c.org/blog/2025/gcp-filestore-backups/)
 
 ## Deploying JupyterHub on public infrastructure
 
@@ -31,9 +31,9 @@ Deploying Kubernetes and JupyterHub on publicly-managed infrastructure could be 
 
 [Open infrastructure for collaborative geoscience with Project Pythia: Learning how to deploy a BinderHub on Jetstream2](https://2i2c.org/blog/2025/jetstream-binderhub/)
 
-***Thanks to** [Jetstream2](https://jetstream-cloud.org/) for an ACCESS allocation, to Julian Pistorius for technical support, to [Project Pythia](https://projectpythia.org/) (NSF award 2324302\) for funding this work, and to [Andrea Zonca](https://www.zonca.dev/posts/2024-12-11-jetstream_kubernetes_magnum) for preliminary work on Kubernetes deployments on Jetstream 2\.*
+_**Thanks to** [Jetstream2](https://jetstream-cloud.org/) for an ACCESS allocation, to Julian Pistorius for technical support, to [Project Pythia](https://projectpythia.org/) (NSF award 2324302) for funding this work, and to [Andrea Zonca](https://www.zonca.dev/posts/2024-12-11-jetstream_kubernetes_magnum) for preliminary work on Kubernetes deployments on Jetstream 2._
 
-## Upgrading to the latest JupyterHub
+## Upgrading to the latest JupyterHub version
 
 We upgraded all of 2i2c’s community hubs to use JupyterHub 5.0. This brings in a bunch of security improvements, bugfixes, and enhancements. You can find links to the highlights and changelog in our blog post below.
 
@@ -56,7 +56,7 @@ Finally, below are a few other blog posts where we’ve documented major impact 
 **Community impact**
 
 - [Harnessing Marine Open Data Science for Ocean Sustainability in Africa, South Asia and Latin America](https://2i2c.org/blog/2025/hackweek-shoutout/)  
-- [NASA VEDA & 2i2c Update for Q4 2024 (Oct-Dec 2024\)](https://2i2c.org/blog/2025/veda-update-q4-2024/)
+- [NASA VEDA & 2i2c Update for Q4 2024 (Oct-Dec 2024)](https://2i2c.org/blog/2025/veda-update-q4-2024/)
 
 **Open Source impact**
 

--- a/content/blog/2025/q1-reflection/index.md
+++ b/content/blog/2025/q1-reflection/index.md
@@ -1,0 +1,79 @@
+---
+title: "Quarterly reflection - 2025Q1"
+authors: ["Chris Holdgraf"]
+categories: [organization]
+date: 2025-04-16
+---
+
+_This is a summary of major progress we made in Q1 of 2025. Its goal is to summarize our major accomplishments and important context before we prioritize for Q2. It is broken down by our functional areas._
+
+Our primary Q1 2025 goal was to build a solid organizational foundation that will enable us to iterate on our product and business model in Q2. We successfully completed our reorganization into dedicated Business Development and Product teams, and implemented a new quarterly target-setting process across the organization. There are still some key remaining areas to make progress on here, and we need to ensure that key KPIs and team responsibilities are solidified quickly in Q2.
+
+Below we’re sharing a brief update about the major achievements across each area of 2i2c, and first thoughts about outcomes to target in Q2 2025.
+
+## Delivery and Enablement
+
+**Goal**: Develop the operating structure and team skills to efficiently scale our product and service delivery.
+
+**Quarterly Objectives**
+
+* **D01**: Re-organize into product-centric team structure. Define new roles, and accountability practices.  
+* **D02**: Define at least one KPI across each of 2i2c’s areas and complete 2-3 iterations of measurement.  
+
+### How we did
+
+We did a good job of taking our first steps at being more structured and intentional about our team and our goals. Our biggest accomplishment was to **significantly improve the Product and Services (P&S) team’s ability to plan and deliver on work**. We are now measuring velocity as a P&S team, and this gives us a much better understanding of our capacity and a means of optimizing it.
+
+We were slower than expected in defining our new team structures - particularly within the Business Development (BD) team, but I’m confident that we are now on the right track. The biggest remaining challenge is to **refine the relationship between BD and P&S so that we have clear responsibility hand-offs.**
+
+We have made progress defining KPIs, but have had uneven success in implementing them across the teams. We defined the BD KPIs later than expected, and as a result **we must still operationalize our measurement of those KPIs.** 
+
+Finally, **we were inconsistent in the way that we completed and documented the work above**, and did not reliably encode outcomes as a “source of truth” in our team compass. This resulted in some confusion about the status, context, and outcomes of some of the team initiatives.
+
+## Product and Services
+
+**Goal**: Create a systematic approach to defining our product value and prioritizing development work.
+
+**Quarterly Objectives**
+
+* **P01:** The Product Menu of current capabilities already exists. The focus now should be on finalizing the Product and Services MVP, which is linked to goal S01  
+* **P02:** Integrate Services into the Product roadmap, prioritizing those needed to enable **S01**  
+* **P03:** We have designed a qualitative survey to benchmark and record customer satisfaction for any newly released product feature. This survey is already in the process of being sent out to customers of the recent Grafana work, and will be sent out to representative customers of subsequent feature releases.
+
+### How we did
+
+We've finalized our product roadmap and incorporated service design priorities into this system as well. It now guides both technical and service development which are the two key ways that we deliver value to our communities. This is a key win for the team, because it means **we can more systematically decide what to build next in order to deliver value to our communities**.
+
+We also collaborated with the BD team to define our menu of options for communities and ensure they are clearly defined and scalable for our team. This involved a lot of extra back-and-forth that wasn’t planned, but was **critical to ensure we had alignment between our business model and our team’s ability to deliver**.
+
+We ran an experiment at conducting community surveys to establish a baseline customer satisfaction KPI and learn if we are building the right things, but didn’t have the response rates that we needed to be useful. **We need to find a way of efficiently creating actionable answers to “are we building the right thing?”**. 
+
+We also agreed on a general principle of measuring community engagement as a primary KPI, but have not yet operationalized it. This is a key metric to **understand whether we’re delivering the value we intend, and whether a community is likely to renew their contract**.
+
+Finally, in some cases we have continued to interact with communities in an unscalable way. This is both true for the ways in which we’ve given communities guidance and training, as well as the ways that the P&S team has supported BD in its sales and marketing efforts. It is critical that we **build scalable systems for delivering services to all of our member communities** to ensure that we deliver value to our entire network of member organizations and not just those we have the strongest connections with. It will also **create more scalable channels of communication and relationship-building with communities** so that we can support and learn from our entire network.
+
+## Business Development
+
+**Goal**: Create a structured service menu and improve sales tracking.
+
+**Quarterly targets**
+
+* **S01: Define a tiered pricing and service model**    
+* **S02: Define a scalable sales system**   
+* **S03: Create and operationalize revenue targets and projections**  
+
+### How we did
+
+Our BD team built a three-tier membership model that combines monthly fees with active user pricing. **This gives us a foundation to iterate on our pricing and business model.** Initial anecdotal feedback from renewing communities has been positive, though **we have not yet systematized a process for collecting and incorporating feedback from communities into our sales assets**.
+
+We've completed the first version of our sales CRM to track all customer conversations and tie them to ongoing opportunities. The **CRM is now being used reliably, and has already generated helpful feedback for improvement**. However **we did not make our intended progress in creating systematized and scalable sales assets**. It will be critical to build these assets quickly so that we can engage in efficient sales conversations and iterate quickly.
+
+We were slower than expected in defining the KPIs that drive BD. We’ve successfully defined the KPIs that should drive BD, but have not operationalized and iterated on business development targets. It will be **critical to measure these BD KPIs and define targets in Q2 in order to set a benchmark of success for BD**.
+
+Finally, we were slower than expected in defining the team structure of BD, due to a diffusion of responsibility stemming from our shared leadership model. We’ve clarified that ambiguity and **now have a defined structure of roles and responsibilities within BD**.
+
+## Concluding thoughts
+
+Overall, I consider this quarter a success, given that we are operating with new systems for planning and executing work, as well as a new team structure. We didn't accomplish everything we set out to do in Q1 2025, but I think that's OK for our first quarterly cycle. In Q2 I expect us to be better at scoping the work we aim to accomplish, as well as holding ourselves accountable for getting it done.
+
+In Q2, we need to prioritize the refinement of our Business Development / Membership model and the system we use for growing and sustaining it. Our P&S team is now much more reliable at planning and delivering work, and our next bottleneck is having a business process that can reliably _generate_ work and revenue that sustains the organization. This will be a key focus in our Q2 planning.

--- a/content/blog/2025/q1-reflection/index.md
+++ b/content/blog/2025/q1-reflection/index.md
@@ -1,13 +1,15 @@
 ---
-title: "Quarterly reflection - 2025Q1"
+title: "2025-Q1 reflection: Building a foundation for our new platform and membership model"
 authors: ["Chris Holdgraf"]
 categories: [organization]
 date: 2025-04-16
 ---
 
-_This is a summary of major progress we made in Q1 of 2025. Its goal is to summarize our major accomplishments and important context before we prioritize for Q2. It is broken down by our functional areas._
+_This is a summary of major progress we made in Q1 of 2025. Its goal is to summarize our major accomplishments and important context before we prioritize for Q2. We hope this gives our community stakeholders a more strategic-level insight into our progress and organizational plans. See [our Product Highlights for 2025Q1](../q1-product-highlights/index.md) for a product-focused review.  Please [give us feedback](mailto:hello@2i2c.org) for how we can provide more useful information._
 
-Our primary Q1 2025 goal was to build a solid organizational foundation that will enable us to iterate on our product and business model in Q2. We successfully completed our reorganization into dedicated Business Development and Product teams, and implemented a new quarterly target-setting process across the organization. There are still some key remaining areas to make progress on here, and we need to ensure that key KPIs and team responsibilities are solidified quickly in Q2.
+Heading into Q1 2025, we had just completed an organizational re-structuring into new functional areas. These were [Products and Services](https://compass.2i2c.org/product-and-services/), [Business Development](https://compass.2i2c.org/biz-dev/), and [Delivery and Team Enablement](https://compass.2i2c.org/delivery-enablement/). Our [support from The Navigation Fund](https://2i2c.org/blog/2024/funding-navigation/) began in January 2025, and we re-organized around the goals defined in that report. Q1 2025 was the first quarterly cycle under this new system.
+
+Our primary Q1 2025 goal was to build a solid organizational foundation that will enable us to iterate on our product and business model in Q2. We successfully completed our reorganization into dedicated Business Development and Product teams, and implemented a new quarterly target-setting process across the organization. There are still some key remaining areas to make progress, and we need to ensure that key KPIs and team responsibilities are solidified quickly in Q2.
 
 Below we’re sharing a brief update about the major achievements across each area of 2i2c, and first thoughts about outcomes to target in Q2 2025.
 
@@ -58,9 +60,9 @@ Finally, in some cases we have continued to interact with communities in an unsc
 
 **Quarterly targets**
 
-* **S01: Define a tiered pricing and service model**    
-* **S02: Define a scalable sales system**   
-* **S03: Create and operationalize revenue targets and projections**  
+* **S01**: Define a tiered pricing and service model
+* **S02**: Define a scalable sales system
+* **S03**: Create and operationalize revenue targets and projections
 
 ### How we did
 

--- a/content/blog/2025/q2-product-goals/index.md
+++ b/content/blog/2025/q2-product-goals/index.md
@@ -1,0 +1,42 @@
+---
+title: "Our Product and Service goals for Q2 2025"
+authors: ["Giuliano Maciocci", "Chris Holdgraf"]
+categories: [organization]
+date: 2025-04-16
+---
+
+As we head into Q2 of 2025, we continue to focus our work on delivering to a small set of core themes we feel reflect our communities’ most pressing needs. As a part of this process, we want to continue sharing our platform and service goals in an effort to remain transparent, as well as to provide our communities with an opportunity to give us feedback on our direction, and on what’s important for them. *See [last quarter’s product goals here](https://2i2c.org/blog/2025/q1-product-goals/).*
+
+The following themes are not guarantees, but should provide a high level view on how we plan to improve our product and services offerings in the next quarter. **If your organization has funding available to support any of the enhancements below, reach out to us and we can discuss how you can help shape our priorities and outcomes**.
+
+## Give administrators more control
+
+The implementation of [per-user storage quotas](https://2i2c.org/blog/2025/per-user-storage-quota-gcp/) in Q1 was the start of a set of product initiatives aimed at giving hub administrators more control and peace of mind over unexpected cost overruns. 
+
+We aim to continue giving administrators more control by implementing the ability to **associate users with groups for usage monitoring**, and as a foundation for future improvements which will deliver **group-level management of storage quotas,** and later Compute and Dask quotas. 
+
+## Improve creating and sharing custom environments
+
+One of the wonderful things about shared open source JupyterHub infrastructure is that it allows community members to share their projects with each other in ways that ensure the work can be fully experienced by the recipient, complete with fully executable content. 
+
+In Q2, we aim to improve the ability for hub users to **build custom environments in their hubs**, and later to easily **share those custom environments with others**, ensuring their entire toolchain is replicated in full. 
+
+## Out-of-the-box Jupyter Book support
+
+We have been working on scoping and building a default JupyterBook implementation [using the new MyST document engine](http://mystmd.org), aiming to deliver a default set of tools for **authoring and sharing documentation**, **customizable landing pages** and **interactive training materials** right out of the box with new hub deployments. 
+
+In Q1 we delivered improvements to the JupyterBook launching interface to allow for **automatic hub type detection**, as well as **landing page components, theming capabilities, galleries and more**. We aim to complete this work in Q2.
+
+## A better onboarding experience for our communities
+
+As more communities in the research and education space join the 2i2c community network, it’s important for us to be ready to deliver the best value we can for them at scale. To that end, we’re **streamlining the processes we use to onboard our communities**, improving the touchpoints through which we engage with them when they join our community network, and ensuring we create opportunities to better understand their needs in order to set them up for success with their hubs right from the start.
+
+## Improve the way we deliver services to our communities
+
+Together with an improved onboarding experience, we aim to improve how we deliver other key services to our communities, including **expert consulting, hub management, and technical support**, with the aim to offer more scalable, high-value services to address the needs of our communities in a sustainable way. 
+
+Some of the goals of this service revamp will include improving triaging of support tickets, shortening our issue response time, and providing our community champions with dedicated expertise on subjects including open source science and tools, community participation in open science, fundraising and grantsmanship co-creation, engineering consultancy and more. 
+
+## Another update coming in Q3
+
+We’ll use this blog post as an informal roadmap of our product goals for the quarter, striving to advance as many of the outlined areas as possible. During our Q3 planning, we’ll reflect on the achievements made in line with this initiative and share a progress update with our community. Keep an eye out for more details\!  

--- a/content/blog/2025/q2-product-goals/index.md
+++ b/content/blog/2025/q2-product-goals/index.md
@@ -5,9 +5,9 @@ categories: [organization]
 date: 2025-04-16
 ---
 
-As we head into Q2 of 2025, we continue to focus our work on delivering to a small set of core themes we feel reflect our communities’ most pressing needs. As a part of this process, we want to continue sharing our platform and service goals in an effort to remain transparent, as well as to provide our communities with an opportunity to give us feedback on our direction, and on what’s important for them. *See [last quarter’s product goals here](https://2i2c.org/blog/2025/q1-product-goals/).*
+_As we head into Q2 of 2025, we continue to focus our work delivering on a small set of core themes that reflect our communities’ most pressing needs. As a part of this process, we want to continue sharing our platform and service goals in an effort to remain transparent, as well as to provide our communities with an opportunity to give us feedback on our direction, and on what’s important for them. See [last quarter’s product goals here](../q1-product-goals/index.md)._
 
-The following themes are not guarantees, but should provide a high level view on how we plan to improve our product and services offerings in the next quarter. **If your organization has funding available to support any of the enhancements below, reach out to us and we can discuss how you can help shape our priorities and outcomes**.
+The following themes are not guarantees, but should provide a high level view on how we plan to improve our product and services offerings in the next quarter. **If your organization has funding available to support any of the enhancements below, [reach out to us](mailto:hello@2i2c.org) and we can discuss how you can shape our priorities and outcomes**.
 
 ## Give administrators more control
 
@@ -23,7 +23,7 @@ In Q2, we aim to improve the ability for hub users to **build custom environment
 
 ## Out-of-the-box Jupyter Book support
 
-We have been working on scoping and building a default JupyterBook implementation [using the new MyST document engine](http://mystmd.org), aiming to deliver a default set of tools for **authoring and sharing documentation**, **customizable landing pages** and **interactive training materials** right out of the box with new hub deployments. 
+We have been working on scoping and building a default JupyterBook implementation [using the new MyST document engine](http://mystmd.org), aiming to deliver a default set of tools for **authoring and sharing documentation**, **customizable landing pages** and **interactive training materials** out of the box with new hub deployments. 
 
 In Q1 we delivered improvements to the JupyterBook launching interface to allow for **automatic hub type detection**, as well as **landing page components, theming capabilities, galleries and more**. We aim to complete this work in Q2.
 
@@ -31,7 +31,7 @@ In Q1 we delivered improvements to the JupyterBook launching interface to allow 
 
 As more communities in the research and education space join the 2i2c community network, it’s important for us to be ready to deliver the best value we can for them at scale. To that end, we’re **streamlining the processes we use to onboard our communities**, improving the touchpoints through which we engage with them when they join our community network, and ensuring we create opportunities to better understand their needs in order to set them up for success with their hubs right from the start.
 
-## Improve the way we deliver services to our communities
+## Improve and formalize the services we deliver to our communities
 
 Together with an improved onboarding experience, we aim to improve how we deliver other key services to our communities, including **expert consulting, hub management, and technical support**, with the aim to offer more scalable, high-value services to address the needs of our communities in a sustainable way. 
 


### PR DESCRIPTION
These are our quarterly community update posts for the Q1/Q2 transition. It includes:

- A product retrospective on Q1
- A product goals for Q2
- An organizational retrospective from Q1