### PR TITLE
Minor language updates to tighten up blog post

### DIFF
--- a/content/blog/2025/jb-for-communities/index.md
+++ b/content/blog/2025/jb-for-communities/index.md
@@ -11,26 +11,28 @@ featured: false
 draft: false
 ---
 
-A core component of our mission to make research and education more _impactful_, _accessible_, and _delightful_ is leveraging our unique [global network of communities][network] to help us make meaningful improvements to the open-source tools that power their work. In this way, our experience of learning from one community can be used to provide value to our entire network e.g. [our work with PACE on speeding up their CNN model training][pace-gpu].
+A core component of our mission to make research and education more _impactful_, _accessible_, and _delightful_ is leveraging our unique [global network of communities][network] to make meaningful improvements to the open-source tools that power their work. Learning from one community can then provide value to our entire network, e.g., [our work with PACE on speeding up their CNN model training][pace-gpu].
 
-At the heart of the work that our communities perform is the fundamental importance of sharing new findings, best-practice, and community resources. Across our network, we have seen communities creating their own "books" that provide a home for this kind of content. Replicated across many of these books is the concept of a "landing page" that welcomes new members, establishes an identity, and provides jumping off points (or "calls to action") into more detailed resources.
+Central to our communities' work is the importance of sharing new findings, best practices, and community resources. Across our network, we have seen communities creating their own "books" that provide a home for this kind of content. Many of these books feature the concept of a "landing page" that welcomes new members, establishes an identity, and provides jumping-off points (or "calls to action") to more detailed resources.
 
-Until now, each community has been required to understake this work themselves. 2i2c believes that by [building upon existing open-source tools][open-tech] like [Jupyter Book 2][jb-next], we can help communities to focus on the _content_ of their home, without having to spend so much time worrying about how to make that content look _good_. To that effect, we have been working on [an initiative][initiative] to allow communities to more rapidly build interactive starter documentation and provide their users with a rich, interactive and informative onboarding experience. Through this initiative, we have:
+Until now, each community has been required to undertake this work independently. 2i2c believes that by [building upon existing open-source tools][open-tech] like [Jupyter Book 2][jb-next], we can help communities focus on the _content_ of their home, rather than spending time worrying about its _appearance_. To that end, we have been working on [an initiative][initiative] to allow communities to rapidly build interactive starter documentation and provide users with a rich, interactive, and informative onboarding experience. Through this initiative, we have:
 
 - Improved the user experience of launching into interactive compute environments from a Jupyter Book.
 - Built components into the Jupyter Book "book theme" for low-density landing page content like call-to-action blocks.
-- Extended our service to co-locate community documentation alongside community hubs (i.e. `docs.hub.2i2c.cloud`).
+- Extended our service to co-locate community documentation alongside community hubs (i.e., `docs.hub.2i2c.cloud`).
 
 ![Screenshot of the 2i2c Showcase Hub landing page](./landing-page.png)
-(A screenshot of the 2i2c [Showcase Hub](https://docs.showcase.2i2c.cloud/) landing page, featuring a simple banner image and call to action.)
+(A screenshot of the 2i2c [Showcase Hub](https://docs.showcase.2i2c.cloud/) landing page, featuring a simple banner image and call-to-action.)
 
-In order to take advantage of this feature, communities can use the [`2i2c-org/community-docs-template`][template] to deploy a Jupyter Book site to GitHub Pages. This template demonstrates some simple usage of Jupyter Book 2 for working with computational content and building a landing page, and establishes the necessary CD workflows to publish the book to the web. Meanwhile, 2i2c can update our domain name management to point the `docs.hub.2i2c.cloud` nested subdomain to the newly deployed documentation.
+To take advantage of this feature, communities can use the [`2i2c-org/community-docs-template`][template] to deploy a Jupyter Book site to GitHub Pages. This template demonstrates simple usage of Jupyter Book 2 for computational content and landing page creation, and establishes the necessary CD workflows for web publication. Meanwhile, 2i2c can update our domain name management to point the `docs.hub.2i2c.cloud` nested subdomain to the newly deployed documentation.
 
-Through building these new capabilities, we learned a lot about what makes building "good" community documentation so difficult. Between a wide range of bespoke tools for building websites, and quirks in integrating them together, it has previously been a lot of work for communities to both keep the documentation up-to-date with changes from within the community, and keep-up with the necessary updates to the software underlying that documentation. We also learned that by trading bespoke complexity for simplicity and readability, we could build a solution that scales to multiple communities, with a consequentially reduced maintenance burden.
+For more information, see [our community documentation for deploying Jupyter Books](svc-guide).
 
-With these improvements, we have tried to start a conversation around what a more unified "look and feel" to our network might look like, and how it might benefit our communities. There is much that can be done to take this first step further, and we are keen to garner feedback on how we can make these features work better for users.
+Developing these new capabilities taught us a lot about what makes building "good" community documentation so difficult. A wide range of bespoke website-building tools and integration quirks previously made it challenging for communities to both keep documentation current with internal changes and keep up with necessary software updates. We also learned that by trading bespoke complexity for simplicity and readability, we could build a solution that scales to multiple communities, with a consequently reduced maintenance burden.
 
-To learn more about this work, why not take a look at a very thin example on [our Showcase Hub](https://docs.showcase.2i2c.cloud/), and check out [our service guide][svc-guide]. [Let us know](https://airtable.com/appM2L2x1uglMU0hy/pagWPJDEKTlLd7uMP/form) what you think!
+With these improvements, we have initiated a conversation about what a more unified "look and feel" for our network might entail, and how it might benefit our communities. Much more can be done to build on this first step, and we are eager to gather feedback on how to improve these features for users.
+
+To learn more about this work, consider exploring a minimal example on [our Showcase Hub](https://docs.showcase.2i2c.cloud/), and check out [our service guide][svc-guide]. [Let us know](https://airtable.com/appM2L2x1uglMU0hy/pagWPJDEKTlLd7uMP/form) what you think!
 
 [pace-gpu]: ../../2024/pace-hackweek/index.md
 [open-tech]: ../community-ownership/index.md


### PR DESCRIPTION
This just tightens up the language in the jupyter book blog post a little bit so that it reads a bit more cleanly (removing adverbs, extra wording, etc). It also fixes a few typos in the content and adds a link to our documentation.