### PR TITLE
Update a few links to our docs and website

### DIFF
--- a/layouts/shortcodes/about-hubs.html
+++ b/layouts/shortcodes/about-hubs.html
@@ -1,5 +1,4 @@
 - [Our Team Compass](https://compass.2i2c.org) contains all of 2i2c's organizational strategy, policy, and team practices.
-- [Our updates blog series](https://2i2c.org/category/updates/) provides all major organizational updates for our community.
-- [Our Service Level Objectives](https://docs.2i2c.org/about/service/service-objectives.html) describes our day-to-day goals running the service.
-- [Our Shared Responsibility Model](https://docs.2i2c.org/about/service/index.html) describes how we collaborate with communities in this hub service.
+- [Our blog](https://2i2c.org/blog) has updates about our service and organization.
+- [Our service documentation](https://docs.2i2c.org) describes our in more detail.
 - [Our Infrastructure Guide](https://infrastructure.2i2c.org/) describes all of our cloud infrastructure and engineering practices, with links to our codebase.


### PR DESCRIPTION
This updates a few links to the `about-hubs` section so that we fix a broken link and so that we direct to more modern content that isn't as outdated