### PR TITLE
blog: Use words for small-ish numbers

### DIFF
--- a/content/blog/2025/automating-support-upgrades/index.md
+++ b/content/blog/2025/automating-support-upgrades/index.md
@@ -26,12 +26,12 @@ Additionally, this failure to scale up was reported to us by the community rathe
 
 ## Structured solutions
 
-We follow a 2 week sprint cycle, and I love the (hard won) structure it provides us. I don't want to arbitrarily start doing work that upsets prior committed work from that structure. However, we also treat support requests seriously and try to work them into the sprint. So I timeboxed myself for 1hr, and saw what I could accomplish. Turns out, a lot!
+We follow a two week sprint cycle, and I love the (hard won) structure it provides us. I don't want to arbitrarily start doing work that upsets prior committed work from that structure. However, we also treat support requests seriously and try to work them into the sprint. So I timeboxed myself for one hour, and saw what I could accomplish. Turns out, a lot!
 
 1. I [upgraded all our support components](https://github.com/2i2c-org/infrastructure/pull/6183), tested them, and rolled them out to *all* our communities! This included upgrading Grafana, Prometheus, nginx-ingress as well as the cluster-autoscaler. This also restarts the cluster-autoscaler across our clusters, fixing this issue for other communities (if any had it).
 2. I [re-enabled](https://github.com/2i2c-org/infrastructure/pull/6182) the automatic once a month PR for upgrading these support tasks. We had switched to doing them on a manual sprint cadence, but clearly that was not fast enough nor automated enough. We will instead work these into the sprint once the bot opens the PR. Credit to [Erik Sundell](https://github.com/consideratio) for initially setting this up
 3. Create [an issue](https://github.com/2i2c-org/infrastructure/issues/6185) to track the alert creation, and put it in our sprint backlog.
-4. (Outside my 1hr timebox, but still with a 15min one) Write this blog post, to communicate out both to the affected communities and others what we have done.
+4. (In an additional fifteen minute timebox) Write this blog post, to communicate out both to the affected communities and others what we have done.
 
 By timeboxing myself, I didn't upset our sprint cadence and was able to continue doing other work I had committed to in the sprint, while also fixing this *class of issues* to the best of my ability.
 


### PR DESCRIPTION
This PR changes small words to numbers in order to improve readability. It also tweaks one sentence.