### PR TITLE
fix: links to CryoCloud

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -137,7 +137,7 @@ sections:
           {{< video src="videos/jupyterbook.mp4">}}
 
           <figcaption>
-              Powered by <a href="https://jupyterbook.org"><img src="/images/logos/project/jupyterbook.svg" /></a> and <a href="https://mystmd.org"><img src="/images/logos/project/myst.svg" /></a>. Example from <a href="https://book.cryointhecloud.com/intro.html">the CryoCloud JupyterBook</a>.
+              Powered by <a href="https://jupyterbook.org"><img src="/images/logos/project/jupyterbook.svg" /></a> and <a href="https://mystmd.org"><img src="/images/logos/project/myst.svg" /></a>. Example from <a href="https://book.cryointhecloud.com">the CryoCloud JupyterBook</a>.
           </figcaption>
         </figure>
 

--- a/content/blog/2023/qgis-greenland/index.md
+++ b/content/blog/2023/qgis-greenland/index.md
@@ -40,6 +40,6 @@ The success of the QGreenland workshop underscores the potential of integrating 
 - [Trey Stafford](https://cires.colorado.edu/people/trey-stafford)[(CIRES)](https://cires.colorado.edu/)
 - [Matthew Fisher](https://cires.colorado.edu/people/matthew-fisher)[(CIRES)](https://cires.colorado.edu/)
 - *Fisher, M., *T. Stafford, T. Moon, and A. Thurber (2023). QGreenland (v3) [software], National Snow and Ice Data Center.
-- Snow, Tasha, Millstein, Joanna, Scheick, Jessica, Sauthoff, Wilson, Leong, Wei Ji, Colliander, James, Pérez, Fernando, James Munroe, Felikson, Denis, Sutterley, Tyler, & Siegfried, Matthew. (2023). [CryoCloud JupyterBook](https://book.cryointhecloud.com/intro.html) (2023.01.26). Zenodo. [10.5281/zenodo.7576602](https://doi.org/10.5281/zenodo.7576602)
+- Snow, Tasha, Millstein, Joanna, Scheick, Jessica, Sauthoff, Wilson, Leong, Wei Ji, Colliander, James, Pérez, Fernando, James Munroe, Felikson, Denis, Sutterley, Tyler, & Siegfried, Matthew. (2023). [CryoCloud JupyterBook](https://book.cryointhecloud.com) (2023.01.26). Zenodo. [10.5281/zenodo.7576602](https://doi.org/10.5281/zenodo.7576602)
 
 \* Denotes co-equal lead authorship

--- a/content/blog/2025/automating-support-upgrades/index.md
+++ b/content/blog/2025/automating-support-upgrades/index.md
@@ -10,7 +10,7 @@ tags:
 
 ## The Problem
 
-Two of our the communities we serve ([NMFS Openscapes](https://nmfs-openscapes.github.io/) and [CryoCloud](https://book.cryointhecloud.com/intro.html)) reported issues with starting GPU nodes on their hubs. Upon investigation, I discovered that the [cluster autoscaler](https://github.com/kubernetes/autoscaler) seems to not recognize that GPUs were available in the cluster at all suddenly, and hence wasn't provisioning the nodes. A restart of the cluster-autoscaler pod fixed the issue for both these communities.
+Two of our the communities we serve ([NMFS Openscapes](https://nmfs-openscapes.github.io/) and [CryoCloud](https://book.cryointhecloud.com)) reported issues with starting GPU nodes on their hubs. Upon investigation, I discovered that the [cluster autoscaler](https://github.com/kubernetes/autoscaler) seems to not recognize that GPUs were available in the cluster at all suddenly, and hence wasn't provisioning the nodes. A restart of the cluster-autoscaler pod fixed the issue for both these communities.
 
 ## An incomplete solution
 


### PR DESCRIPTION
The move of the CryoCloud Book to MyST broke some links.