### PR TITLE
BLOG - q2 post and add links to user documentation

### DIFF
--- a/content/blog/2025/jb-for-communities/index.md
+++ b/content/blog/2025/jb-for-communities/index.md
@@ -11,6 +11,10 @@ featured: false
 draft: false
 ---
 
+We're excited to announce out-of-the-box support for [Jupyter Book 2](https://next.jupyterbook.org) for our community members. This allows communities to create and share knowledge bases together for their community workflows. This post describes the motivation behind this new functionality, and how you can learn more about the project.
+
+> ⭐ **Members of 2i2c's community network** can use this feature in their hubs by following [our documentation and sharing documentation](https://docs.2i2c.org/sharing/documentation/).
+
 A core component of our mission to make research and education more _impactful_, _accessible_, and _delightful_ is leveraging our unique [global network of communities][network] to make meaningful improvements to the open-source tools that power their work. Learning from one community can then provide value to our entire network, e.g., [our work with PACE on speeding up their CNN model training][pace-gpu].
 
 Central to our communities' work is the importance of sharing new findings, best practices, and community resources. Across our network, we have seen communities creating their own "books" that provide a home for this kind of content. Many of these books feature the concept of a "landing page" that welcomes new members, establishes an identity, and provides jumping-off points (or "calls to action") to more detailed resources.

--- a/content/blog/2025/jb-for-communities/index.md
+++ b/content/blog/2025/jb-for-communities/index.md
@@ -13,7 +13,7 @@ draft: false
 
 We're excited to announce out-of-the-box support for [Jupyter Book 2](https://next.jupyterbook.org) for our community members. This allows communities to create and share knowledge bases together for their community workflows. This post describes the motivation behind this new functionality, and how you can learn more about the project.
 
-> ⭐ **Members of 2i2c's community network** can use this feature in their hubs by following [our documentation and sharing documentation](https://docs.2i2c.org/sharing/documentation/).
+> ⭐ **Members of 2i2c's community network** can use this feature in their hubs by following [our documentation and sharing guide](https://docs.2i2c.org/sharing/documentation/).
 
 A core component of our mission to make research and education more _impactful_, _accessible_, and _delightful_ is leveraging our unique [global network of communities][network] to make meaningful improvements to the open-source tools that power their work. Learning from one community can then provide value to our entire network, e.g., [our work with PACE on speeding up their CNN model training][pace-gpu].
 

--- a/content/blog/2025/jetstream2-persistent-hub/index.md
+++ b/content/blog/2025/jetstream2-persistent-hub/index.md
@@ -15,7 +15,10 @@ When we first committed to offer [Jetstream2](https://jetstream-cloud.org/index.
 And although the initial exercise of reading about each of them independently was confusing, learning how they actually glued together was the key.
 This post is about Jetstream2, 2i2c persistent hub offerings, and the learning that took place in the process.
 
+> ⭐ **Members of 2i2c's community network** can learn how to use JetStream2 in their hubs by [following our JetStream 2 deployment documentation](TODO: MISSING LINK).
+
 ## Context
+
 At 2i2c, we want to be able to deploy k8s clusters on different cloud providers. In a very simplistic way, for this we use:
 
 - `Infrastructure as code` to describe, deploy and manage the actual physical infrastructure from the cloud providers

--- a/content/blog/2025/jetstream2-persistent-hub/index.md
+++ b/content/blog/2025/jetstream2-persistent-hub/index.md
@@ -15,7 +15,7 @@ When we first committed to offer [Jetstream2](https://jetstream-cloud.org/index.
 And although the initial exercise of reading about each of them independently was confusing, learning how they actually glued together was the key.
 This post is about Jetstream2, 2i2c persistent hub offerings, and the learning that took place in the process.
 
-> ⭐ **Members of 2i2c's community network** can determine their eligibility and learn how to use JetStream2  by [following the JetStream 2 getting started guide](https://jetstream-cloud.org/get-started/index.html). If needed, [reach out to 2i2c for support](https://docs.2i2c.org/support/).
+> ⭐ **Members of 2i2c's community network** can determine their eligibility and learn about JetStream2 in [our supported cloud providers documentation](https://docs.2i2c.org/about/distributions/#jetstream2). If needed, [reach out to 2i2c for support](https://docs.2i2c.org/support/).
 
 ## Context
 

--- a/content/blog/2025/jetstream2-persistent-hub/index.md
+++ b/content/blog/2025/jetstream2-persistent-hub/index.md
@@ -15,7 +15,7 @@ When we first committed to offer [Jetstream2](https://jetstream-cloud.org/index.
 And although the initial exercise of reading about each of them independently was confusing, learning how they actually glued together was the key.
 This post is about Jetstream2, 2i2c persistent hub offerings, and the learning that took place in the process.
 
-> ⭐ **Members of 2i2c's community network** can learn how to use JetStream2 in their hubs by [following our JetStream 2 deployment documentation](TODO: MISSING LINK).
+> ⭐ **Members of 2i2c's community network** can determine their eligibility and learn how to use JetStream2  by [following the JetStream 2 getting started guide](https://jetstream-cloud.org/get-started/index.html). If needed, [reach out to 2i2c for support](https://docs.2i2c.org/support/).
 
 ## Context
 

--- a/content/blog/2025/jupyterhub-groups-exporter/index.md
+++ b/content/blog/2025/jupyterhub-groups-exporter/index.md
@@ -11,6 +11,8 @@ draft: false
 
 Managing user groups in JupyterHub can be a challenging task, especially in environments with dynamic user bases and complex group structures. This post describes how we can leverage the latest group management features in JupyterHub, along with Prometheus and Grafana, to monitor group-level resource usage effectively.
 
+> ⭐ **Members of 2i2c's community network** can use this feature in their hubs by [following our cost attribution documentation](https://docs.2i2c.org/admin/howto/monitoring/cost-attribution/).
+
 ![Grafana User Group Diagnostics Dashboard showing a memory usage over time with each line aggregating usage over a different user group.](./featured.png)
 
 ## Motivation

--- a/content/blog/2025/q2-highlights/index.md
+++ b/content/blog/2025/q2-highlights/index.md
@@ -1,0 +1,50 @@
+---
+authors:
+- Giuliano Maciocci
+- Chris Holdgraf
+- April Johnson
+date: 2025-07-21
+category: Organization
+title: Product and team highlights from Q2 2025
+---
+
+
+This post highlights what stood out to us from last quarter and reflects on the [targets we set at the start of the quarter](https://2i2c.org/blog/2025/q2-product-goals/).
+
+This quarter, our team learned the importance of shipping iteratively and inviting feedback frequently. In some cases, we learned this the hard way - having spent multiple cycles developing without feedback from community representatives. In other cases, we made rapid progress by working in collaboration with community members in our network. This quarter, we are leaning into this approach as we work towards **building a more standardized and sustainable service** for our community network.
+
+Here's what stood out from the quarter:
+
+## Group-level resource monitoring
+
+Building on our previous work delivering [usage monitoring using Prometheus and Grafana](https://2i2c.org/blog/2024/aws-cost-attribution/), we've released [jupyterhub-groups-exporter](https://2i2c.org/blog/2025/jupyterhub-groups-exporter/), allowing hub administrators to leverage the latest group management features in JupyterHub to monitor group-level resource usage effectively, making it easier to identify usage patterns across teams and departments.
+
+> ⭐ Members of 2i2c's community network can learn how to use this in [our user guide to usage monitoring](https://docs.2i2c.org/admin/howto/monitoring/grafana-dashboards/#getting-a-grafana-account). See this [blog post announcing `jupyterhub-groups-exporter`](https://2i2c.org/blog/2025/jupyterhub-groups-exporter/).
+
+## Improve creating and sharing custom environments
+
+Last year we introduced [customizable servers via profile lists](https://2i2c.org/blog/2024/jupyterhub-fancy-profiles-rollout/). We're building on that - servers can now be configured to [allow users to dynamically specify, build, and share their own custom environment images](https://docs.2i2c.org/user/topics/dynamic-imagebuilding/) without the need for a hub administrator. This will allow community champions with diverse user bases to give their users greater flexibility to support a wide variety of custom computational workflows, accelerating knowledge discovery and sharing. Look out for a blog post on this development in the coming weeks and months.
+
+> ⭐ Members of 2i2c's community network can learn how to use this in our **[dynamic image building quick start guide](https://docs.2i2c.org/user/topics/dynamic-imagebuilding/)**.
+
+## Co-located narrative content with out-of-the-box Jupyter Book support
+
+Central to our communities' work is sharing new findings, best practices, and community resources. To facilitate that, we've added support for [Jupyter Book 2](http://next.jupyterbook.org) for all of our member communities. Our communities can rapidly build interactive starter documentation and provide users with a rich, interactive, and informative onboarding experience. With a suite of customizable landing-page layouts, colour themes, and component galleries ready to match a community's branding, it's now easier than ever to couple a hub with its own co-located narrative content.
+
+> ⭐ Members of 2i2c's community network can learn how to use this in [our user guide to documentation and sharing](https://docs.2i2c.org/admin/howto/monitoring/cost-attribution/). See [this blog post for an announcement](https://2i2c.org/blog/2025/jb-for-communities/).
+
+## A better onboarding experience for our communities
+
+We have been working on a streamlined onboarding experience for communities, smoothing out the process of gathering requirements, customizing a hub for the community's specific needs, and delivering new hubs more rapidly. We will be rolling out this process in the next few weeks for new communities onboarding the 2i2c network, and aim to continue learning and refining this process to deliver a faster, smoother onboarding experience for everyone.
+
+> ⭐ Members of 2i2c's community network will see **changes to our process** over the coming months that increase the speed and ease of hub delivery.
+
+## Efforts to improve and formalize the services we deliver to our communities
+
+As 2i2c has grown over the past few years, it organically developed internal processes for handling common tasks such as the management, rollout and maintenance of hubs, as well as expect consulting to help our communities get the most value out of their hubs. Earlier in the year, we realised it was time to review and refine these processes to better serve our growing community network. As a result of this exercise, we now have tighter service definitions and best practices which clarify what service levels our communities can expect, and how we can internally meet those expectations. We will be publishing our service definitions in the coming months as they are finalized, to ensure full transparency with our communities.
+
+> ⭐ You can learn more about our efforts to standardize and scale our services by [following the 2i2c blog](http://2i2c.org/blog), where we'll share our work as it stabilizes.
+
+## Another update coming in Q3
+
+We'll be announcing the focus for our next quarter in a follow-up post, so stay tuned for our next roadmap update, and don't forget to [let us know what you think](https://docs.google.com/forms/d/e/1FAIpQLSfo6JFr9L5gEFpk_QjoR23YZ9GHXYaO-3WZWZV3qRz8pj7dbg/viewform?usp=dialog) of our direction - we welcome your feedback!


### PR DESCRIPTION
This adds a few links to user documentation for a few of our product-related blog posts. It makes this very clear at the top of each post.

### To do

- [x] Check is this docs PR is enough to unblock the jetstream2 link: https://github.com/2i2c-org/docs/pull/260/files#diff-caed38d6c2672469ca6aa14382c91180d77c31c8d89b6fa157009c71d8e60c51R70-R91
- [x] Double-check that I've linked to all the correct places in docs.2i2c.org for these links.
- [x] Add a link to user documentation for JetStream2. (I couldn't find any documentation about this)