### PR TITLE
Tighten up homepage content and add list of blog posts

### DIFF
--- a/assets/scss/pages/_home.scss
+++ b/assets/scss/pages/_home.scss
@@ -27,3 +27,62 @@ ul.cta-group {
     max-height: 80vh;
     overflow-y: auto;
 }
+
+// Blog cards grid - responsive layout for recent posts
+.blog-cards-grid {
+    .archive {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 2rem;
+
+        // 2 cards on tablets+
+        @media (min-width: 768px) {
+            grid-template-columns: repeat(3, 1fr);
+        }
+    }
+}
+
+// Recent posts in a single row on medium+ screens
+.recent-posts-row {
+    .col-12 {
+        .card {
+            display: flex;
+            flex-direction: column;
+
+            .card-image {
+                height: 200px;
+                overflow: hidden;
+                flex-shrink: 0;
+
+                img {
+                    width: 100%;
+                    height: 100%;
+                    object-fit: cover;
+                }
+            }
+
+            .card-text {
+                flex-grow: 1;
+            }
+        }
+
+        // Single row on medium and larger screens
+        @media (min-width: 768px) {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1.5rem;
+            align-items: stretch;
+
+            .card {
+                flex: 1;
+                min-width: 0; // Prevent flex items from overflowing
+                margin-bottom: 0;
+            }
+
+            .see-all {
+                flex-basis: 100%; // Force see-all to take full width and wrap to new line
+                margin-top: 0;
+            }
+        }
+    }
+}

--- a/content/_index.md
+++ b/content/_index.md
@@ -47,7 +47,7 @@ sections:
 
         {{< servicetech >}}
        
-        2i2c's [community membership model](./join/_index.md) gives communities access to our [hub platform and services](/platform) so that your community can create an share knowledge with your own open infrastructure. We serve [over 90 member communities](./members/index.md) in research and education. See [our community impact stories](/communities) for inspiration.
+        Membership in 2i2c's [community network](./join/_index.md) provides access to our [hub platform and services](/platform) so your community can create an share knowledge with your own open infrastructure. We serve [over 90 communities](./members/index.md) in research and education. See [our community impact stories](/communities) for inspiration.
         
 
         <style>
@@ -77,7 +77,7 @@ sections:
   - block: collection
     id: posts
     content:
-      title: Blog updates
+      title: From our blog
       subtitle: The [2i2c blog](./blog/_index.md) shares our recent enhancements and impact.
       count: 3
       filters:

--- a/content/_index.md
+++ b/content/_index.md
@@ -41,15 +41,14 @@ sections:
   - block: markdown
     id: service
     content:
-      title: We help communities build their own interactive computing hub in the cloud with open infrastructure
+      title: We give communities a digital hub with the tools, resources, and data for their workflows
       subtitle: 
       text: |
 
         {{< servicetech >}}
-
-        2i2c stands for **the International Interactive Computing Collaboration**. Our [community hub platform and consultancy services](/platform) ensure your community makes the best use of open infrastructure for interactive computing in the cloud.
-
-        We serve **over 90 communities across the globe** with **over 7000 active users** dedicated to creating and sharing knowledge. See [our community impact stories](/communities) for inspiration.
+       
+        2i2c's [community membership model](./join/_index.md) gives communities access to our [hub platform and services](/platform) so that your community can create an share knowledge with your own open infrastructure. We serve [over 90 member communities](./members/index.md) in research and education. See [our community impact stories](/communities) for inspiration.
+        
 
         <style>
           #who-logos {
@@ -74,6 +73,29 @@ sections:
         </ul>
 
         {{< cta cta_text="Join our network of community hubs" cta_link="/join" cta_new_tab="false" >}}
+
+  - block: collection
+    id: posts
+    content:
+      title: Blog updates
+      subtitle: The [2i2c blog](./blog/_index.md) shares our recent enhancements and impact.
+      count: 3
+      filters:
+        folders:
+          - blog
+        exclude_featured: false
+        exclude_future: false
+        exclude_past: false
+      offset: 0
+      order: desc
+      archive:
+        enable: true
+        text: View all blog posts
+        link: /blog/
+    design:
+      view: masonry
+      columns: '1'
+      css_class: 'recent-posts-row'
 
   - block: markdown
     id: jupyterhub
@@ -206,7 +228,7 @@ sections:
     id: learnplatform
     content:
       title: Learn more about our platform.
-      subtitle: 
+      subtitle:
       text: |
 
         {{< cta cta_text="Learn about our interactive computing platform" cta_link="/platform" cta_new_tab="false" >}}

--- a/contribute/newsletter.md
+++ b/contribute/newsletter.md
@@ -13,9 +13,9 @@ In [Month] we focused on [big theme that stands out and major takeaways]. We [ac
 [/Intro]
 
 [Highlights]
-<p class="category-label [category]">[category nam with spaces not -]</p>
+## [Category]
 
-## [Title of Featured Post N (1-3 total)]
+### [Title of Featured Post in category (1-3 total)]
 
 [Description - 1-3 sentences describing what happened, why it matters, and any important information a user would want to know.]
 
@@ -30,6 +30,13 @@ Read more 👉 [url-without-https://](url)
 
 ## [Title of Featured Post N+1 etc]
 [/Highlights]
+
+[Community]
+## From the community
+
+- [community] did [thing with link to their post]
+- [open source project] released [link to release of version NN]
+[/Community]
 ---
 
 _Here's a list of all the blog posts we published in [Month Year]._


### PR DESCRIPTION
This does a couple things:

- Shrinks some of the text on our home page so that there's only 1 paragraph describing the service and member network.
- Adds the 3 latest blog posts in a card view.