### PR TITLE
Skip oxipng in github action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,11 +28,6 @@ jobs:
           pip install -r requirements.txt
           python scripts/extract_org_logos.py
 
-      - name: Run pre-commit checks
-        uses: pre-commit/action@v3.0.1
-        env:
-          SKIP: oxipng
-
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Run pre-commit checks
         uses: pre-commit/action@v3.0.1
+        env:
+          SKIP: oxipng
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2


### PR DESCRIPTION
because we're using the pre-commit CI job directly we can remove it from the github workflow