### PR TITLE
Update menus with roadmap

### DIFF
--- a/assets/scss/sections/_navbar.scss
+++ b/assets/scss/sections/_navbar.scss
@@ -15,4 +15,18 @@ nav.navbar {
     padding-top: .1rem;
     padding-bottom: .1rem;
   }
+
+  .menu-badge {
+    background: $color-secondary;
+    border-radius: 999px;
+    color: #fff;
+    display: inline-block;
+    font-size: .6em;
+    font-weight: 700;
+    letter-spacing: .04em;
+    line-height: 1;
+    padding: .15rem .2rem;
+    text-transform: uppercase;
+    vertical-align: text-top;
+  }
 }

--- a/assets/scss/sections/_navbar.scss
+++ b/assets/scss/sections/_navbar.scss
@@ -20,7 +20,7 @@ nav.navbar {
     background: $color-secondary;
     border-radius: 999px;
     color: #fff;
-    display: inline-block;
+    display: inline;
     font-size: .6em;
     font-weight: 700;
     letter-spacing: .04em;

--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -9,66 +9,40 @@
   weight = 10
 
 [[main]]
-  name = "Impact"
-  weight = 11
-
-[[main]]
-  name = "Impact stories"
-  parent = "Impact"
-  url = "impact/"
-  weight = 11
-
-[[main]]
-  name = "Case studies"
-  parent = "Impact"
-  url = "case-studies/"
-  weight = 14
-
-[[main]]
-  name = "Member communities"
-  parent = "Impact"
-  url = "members/"
-  weight = 12
-  
-[[main]]
-  name = "Collaborators and funders"
-  parent = "Impact"
-  url = "collaborators/"
-  weight = 13
-
-[[main]]
-  name = "Our Principles"
-  weight = 12
-
-[[main]]
-  parent = "Our Principles"
-  name = "Open Practices"
-  url = "open-practices/"
-  weight = 11
-
-[[main]]
-  parent = "Our Principles"
-  name = "Right to Replicate"
-  url = "right-to-replicate/"
-  weight = 13
-
-[[main]]
-  parent = "Our Principles"
-  name = "Commitment to Open Technology"
-  url = "open-technology/"
-  weight = 13
-
-
-[[main]]
   name = "About"
   identifier = "about"
-  weight = 30
+  weight = 20
 
   [[main]]
   parent = "about"
   name = "Mission and goals"
   url = "mission/"
   weight = 10
+
+  [[main]]
+  parent = "about"
+  name = "Our Principles"
+  identifier = "principles"
+  url = "open-practices/"
+  weight = 12
+
+  [[main]]
+  parent = "principles"
+  name = "Open Practices"
+  url = "open-practices/"
+  weight = 11
+
+  [[main]]
+  parent = "principles"
+  name = "Right to Replicate"
+  url = "right-to-replicate/"
+  weight = 13
+
+  [[main]]
+  parent = "principles"
+  name = "Commitment to Open Technology"
+  url = "open-technology/"
+  weight = 13
 
   [[main]]
   parent = "about"
@@ -100,17 +74,50 @@
   url = "jobs/"
   weight = 60
 
-  [[main]]
-  name = 'Blog'
+[[main]]
+  name = "Impact"
+  weight = 30
+
+[[main]]
+  name = "Impact stories"
+  parent = "Impact"
+  url = "impact/"
+  weight = 11
+
+[[main]]
+  name = "Case studies"
+  parent = "Impact"
+  url = "case-studies/"
+  weight = 14
+
+[[main]]
+  name = "Member communities"
+  parent = "Impact"
+  url = "members/"
+  weight = 12
+  
+[[main]]
+  name = "Collaborators and funders"
+  parent = "Impact"
+  url = "collaborators/"
+  weight = 13
+
+[[main]]
+  name = "Roadmap <span class=\"menu-badge\">NEW</span>"
+  url = "roadmap/"
+  weight = 40
+
+[[main]]
+  name = "Docs"
+  url = "https://docs.2i2c.org"
+  weight = 50
+
+[[main]]
+  name = "Blog"
   url = "/blog"
-  weight = 90
+  weight = 60
 
 [[main_right]]
-  name = 'Membership'
+  name = "Join our network"
   url = "/join"
   weight = 90
-
-[[main_right]]
-  name = 'Docs'
-  url = "https://docs.2i2c.org"
-  weight = 100

--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -104,6 +104,7 @@
 
 [[main]]
   name = "Roadmap <span class=\"menu-badge\">NEW</span>"
+  # This is actually served from the 2i2c-org/roadmap repository
   url = "roadmap/"
   weight = 40
 


### PR DESCRIPTION
This updates our navigation bar with a link to our roadmap, and collapses down some of the menus along the way.

It removes some of the "open principles" sections so that we don't have too much menu clutter...I am not sure how to keep them without making too many menu items! :-/

🖼️ [Demo here](https://deploy-preview-581--cocky-booth-e7ed17.netlify.app/)

<img width="2760" height="490" alt="CleanShot 2026-01-29 at 15 50 33@2x" src="https://github.com/user-attachments/assets/16dcae92-1398-4eff-9133-20bee7c62450" />
