### PR TITLE
`blog`: fix broken link in an old blog post

### DIFF
--- a/content/blog/2024/dei-leadership-strategy/index.md
+++ b/content/blog/2024/dei-leadership-strategy/index.md
@@ -35,7 +35,7 @@ However, over the past few months, we have reflected on our organization's struc
 
 We need to do better.
 
-2i2c is at a moment of maturation and growth as an organization, kicked off by [our organizational audit from 2023](../2023/organizational-report/index.md) as well as [our three-year retrospective](../report-czi/index.md).
+2i2c is at a moment of maturation and growth as an organization, kicked off by [our organizational audit from 2023](../../2023/organizational-report/index.md) as well as [our three-year retrospective](../report-czi/index.md).
 We believe that improving the diversity of leadership throughout the organization is a necessary part of that maturation over the next three years.
 
 Below are a few ideas for how we aim to make improvements, and we invite feedback from others who are interested in helping us improve this aspect of our organization.


### PR DESCRIPTION
I was reading through the DEI leadership strategy [blog post](https://2i2c.org/blog/dei-leadership-strategy/) from 2023 and came across a [broken link](https://2i2c.org/blog/2023/organizational-report/index.md) for the 2023-organizational-audit (incorrect path).

PS: I noticed this repo already uses [lychee](https://github.com/lycheeverse/lychee) in both the [GitHub Action workflow](https://github.com/2i2c-org/2i2c-org.github.io/blob/main/.github/workflows/linkcheck.yml#L28-L43) and the [nox](https://github.com/2i2c-org/2i2c-org.github.io/blob/main/noxfile.py#L52-L61)[ linkcheck](https://github.com/2i2c-org/2i2c-org.github.io/blob/main/noxfile.py#L52-L61)[ session](https://github.com/2i2c-org/2i2c-org.github.io/blob/main/noxfile.py#L52-L61), both target the built HTML so relative link issues in source Markdown can slip through(?). Running `lychee` directly on `content/**/*.md` using [--base-url](https://lychee.cli.rs/recipes/base-url/) could catch these earlier, before the build (though I don't think it will correctly resolve deeply nested relative paths (e.g. ../../) since the flag applies the same base to all files regardless of the depth)...