### PR TITLE
Make netlify not be indexable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,12 @@ It is built from the [academic hugo theme](https://github.com/HugoBlox).
 
 ## Where the website is hosted
 
-This website is **hosted** by GitHub Pages, and we use Netlify to display previews of the website from PRs.
+The production site at https://2i2c.org is **hosted on GitHub Pages**.
+It is built and deployed from `main` by [`.github/workflows/deploy.yml`](./.github/workflows/deploy.yml).
+
+**Netlify is only used for pull request deploy previews**.
+It does not serve the production site.
+The Netlify build is configured in [`netlify.toml`](./netlify.toml).
 
 ## How to edit, build, and preview this website
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,7 @@
+# Production 2i2c.org is served from GitHub Pages.
+# Netlify is used ONLY for pull request deploy previews, so we tell search
+# engines not to index any of these URLs.
+
 [build]
   command = "python scripts/add_slugs_to_blog_posts.py && pip install -r requirements.txt && python scripts/extract_org_logos.py && hugo --gc --minify -b $URL"
   publish = "public"
@@ -6,14 +10,16 @@
   HUGO_VERSION = "0.125.3"
   HUGO_ENABLEGITINFO = "true"
 
-[context.production.environment]
-  HUGO_ENV = "production"
-
 [context.deploy-preview]
   command = "python scripts/add_slugs_to_blog_posts.py && pip install -r requirements.txt && python scripts/extract_org_logos.py && hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy]
   command = "python scripts/add_slugs_to_blog_posts.py && pip install -r requirements.txt && python scripts/extract_org_logos.py && hugo --gc --minify -b $DEPLOY_PRIME_URL"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Robots-Tag = "noindex, nofollow"
 
 [[plugins]]
   package = "netlify-plugin-hugo-cache-resources"


### PR DESCRIPTION
I realized that our netlify build was still indexable, so I've updated that and the docs so it isn't (because we use github pages for 2i2c.org's production site)