### PR TITLE
Update our membership and landing page docs around DOCS / multiple services etc

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -72,7 +72,7 @@
   weight = 30
 
 [[main]]
-  name = "Stories"
+  name = "Impact"
   parent = "Communities"
   url = "impact/"
   weight = 11

--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -18,7 +18,7 @@
   weight = 30
 
 [[main]]
-  name = "Impact"
+  name = "Impact & Stories"
   parent = "Communities"
   url = "impact/"
   weight = 11

--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -14,9 +14,43 @@
   weight = 15
 
 [[main]]
+  name = "Communities"
+  weight = 30
+
+[[main]]
+  name = "Impact"
+  parent = "Communities"
+  url = "impact/"
+  weight = 11
+
+[[main]]
+  name = "Case studies"
+  parent = "Communities"
+  url = "case-studies/"
+  weight = 14
+
+[[main]]
+  name = "Member communities"
+  parent = "Communities"
+  url = "members/"
+  weight = 12
+
+[[main]]
+  name = "Collaborators and funders"
+  parent = "Communities"
+  url = "collaborators/"
+  weight = 13
+
+[[main]]
+  name = "Roadmap <span class=\"menu-badge\">NEW</span>"
+  # This is actually served from the 2i2c-org/roadmap repository
+  url = "https://2i2c.org/roadmap/"
+  weight = 40
+
+[[main]]
   name = "About"
   identifier = "about"
-  weight = 25
+  weight = 45
 
   [[main]]
   parent = "about"
@@ -66,40 +100,6 @@
   name = "Newsletter"
   url = "mailing-list/"
   weight = 80
-
-[[main]]
-  name = "Communities"
-  weight = 30
-
-[[main]]
-  name = "Impact"
-  parent = "Communities"
-  url = "impact/"
-  weight = 11
-
-[[main]]
-  name = "Case studies"
-  parent = "Communities"
-  url = "case-studies/"
-  weight = 14
-
-[[main]]
-  name = "Member communities"
-  parent = "Communities"
-  url = "members/"
-  weight = 12
-
-[[main]]
-  name = "Collaborators and funders"
-  parent = "Communities"
-  url = "collaborators/"
-  weight = 13
-
-[[main]]
-  name = "Roadmap <span class=\"menu-badge\">NEW</span>"
-  # This is actually served from the 2i2c-org/roadmap repository
-  url = "https://2i2c.org/roadmap/"
-  weight = 40
 
 [[main]]
   name = "Docs"

--- a/content/_index.md
+++ b/content/_index.md
@@ -108,16 +108,16 @@ sections:
   - block: features
     id: why-2i2c
     content:
-      title: What makes us different
+      title: How we work
       items:
         - name: Non-profit, no vendor lock-in
           icon: lock-open
           icon_pack: fas
-          description: We exist to serve research and education communities, not shareholders. Your [Right to Replicate](/right-to-replicate) means you can take your infrastructure anywhere, with or without us.
+          description: As a non-profit, our only obligation is to the research and education communities we serve. Your [Right to Replicate](/right-to-replicate) means you can take your infrastructure anywhere, with or without us.
         - name: Open source collaboration
           icon: arrows-spin
           icon_pack: fas
-          description: We listen to researchers and educators, then work with upstream open source projects on solutions that benefit everyone — not just our members.
+          description: We listen to researchers and educators, then work with upstream open source projects on solutions that benefit the whole ecosystem, not just our members.
         - name: Cross-community learning
           icon: people-arrows
           icon_pack: fas

--- a/content/_index.md
+++ b/content/_index.md
@@ -12,13 +12,13 @@ sections:
     content:
       title: Open infrastructure for research and education
       cta:
-        label: How our model works
-        url: /membership
+        label: See how it works
+        url: /platform
       cta_alt:
         label: Join our network
         url: /join
       text: |-
-        We're a non-profit that believes communities shouldn't choose between managing their own servers and vendor lock-in. We operate shared cloud infrastructure so you can focus on discovery, and we contribute to the open source tools that make it possible.
+        We're a non-profit that believes communities shouldn't choose between managing their own servers and vendor lock-in. We operate shared cloud infrastructure so your community can focus on its work, not its servers, and we invest back into the open source tools that make it possible.
     design:
       background:
         text_color_light: true
@@ -53,7 +53,7 @@ sections:
                     <span class="h2 font-weight-bold mb-0">>15</span>
                 </div>
                 <div class="stat col-3">
-                    <h5 class="card-title text-uppercase text-muted mb-0">Upstream PRs</h5>
+                    <h5 class="card-title text-uppercase text-muted mb-0">Upstream PRs contributed</h5>
                     <span class="h2 font-weight-bold mb-0">>2000</span>
                 </div>
             </div>
@@ -97,18 +97,12 @@ sections:
           </figcaption>
         </figure>
 
-        <div class="row row-cols-3 mt-4">
-          <div class="col text-center"><strong>Custom environments</strong><br/>Choose from community-maintained stacks or bring your own.</div>
-          <div class="col text-center"><strong>Managed access</strong><br/>Community leaders control who can use the hub.</div>
-          <div class="col text-center"><strong>Scalable compute</strong><br/>From laptops to GPUs, sized for your workflows.</div>
-        </div>
-
-        {{< cta cta_text="Explore platform features" cta_link="/platform" cta_new_tab="false" >}}
+        {{< cta cta_text="See how communities use their hubs" cta_link="/case-studies" cta_new_tab="false" >}}
 
   - block: features
     id: why-2i2c
     content:
-      title: How we work
+      title: How we are different
       items:
         - name: Non-profit, no vendor lock-in
           icon: lock-open

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -1,0 +1,8 @@
+---
+title: About 2i2c
+---
+
+<!-- This is an intentionally tiny stub page, because Hugo seems to generate an about.html page if we don't create one ourselves. It's not linked in our site nav, but a person might find it via searching on the web or a direct URL, so this just has *some* kind of content there. -->
+2i2c is a non-profit that operates shared cloud infrastructure for research and education communities.
+Learn about [our mission](/mission) and the [team and governance behind 2i2c](/organization).
+You can also read about [how we are funded](/about/funding) and [our commitment to open practices](/open-practices).

--- a/content/impact/index.md
+++ b/content/impact/index.md
@@ -1,5 +1,5 @@
 ---
-title: Stories
+title: Impact & Stories
 type: landing
 
 # Your landing page sections - add as many different content blocks as you like

--- a/content/membership/_index.md
+++ b/content/membership/_index.md
@@ -53,19 +53,20 @@ sections:
     content:
       title: Membership options and pricing
       text: |
-        <!-- MAINTAINER NOTE: the $15k / $50k caps and "free above 10,000 users" also appear on sales.2i2c.org/service-description and compass pricing-strategy.md. If a figure changes, update all three. -->
-        Your total cost is predictable and bounded: a fixed annual fee, a usage fee that caps as your community grows, and cloud passed through at cost.
+        <!-- NOTE: the numbers here also appear at sales.2i2c.org/service-description
+        so make sure to mirror the changes! -->
+        Membership is a fixed annual amount that supports our mission and key member services. Where we run infrastructure for members, we add bounded usage costs to cover the time and cloud fees that we incur with extra usage.
 
-        **Base membership.** A fixed annual fee at one of two tiers. Both cover all four areas of our work; they differ in how much time and strategic attention you get.
+        **Base membership.** A fixed annual fee at one of two tiers. Both cover all four areas of our work. They differ in how much time and strategic attention you get.
 
-        - **General**: For communities that want to benefit from our core shared platform and team. We operate your hub, support your community, and include you in the building, stewarding, and connecting we do for the whole network.
-        - **Premier**: For communities that want to support open source, our mission, and who want deeper engagement with our team. Includes more service hours across all four areas, plus a deeper strategic relationship, including optional monthly strategy sessions, quarterly roadmap reviews, and collaborative work time with our team.
+        - **General**: For communities that want to benefit from our core shared platform and team. We'll operate your hub, support your community, and steward open source projects on your behalf.
+        - **Premier**: For communities that want to support open source, our mission, and who want deeper engagement with our team and member network. Includes more service hours across all four areas, plus a deeper strategic relationship, including optional monthly strategy sessions, quarterly roadmap reviews, and collaborative work time with our team.
 
         See [the service description](https://sales.2i2c.org/service-description) for the services included with each tier.
 
         **Directed engagements.** Fund extra dedicated work in any of the four areas described above. For example, you can support development from [our roadmap](https://2i2c.org/roadmap), more complex infrastructure operations, or dedicated upstream stewardship time. Some organizations also fund larger [project collaborations](/collaborators) alongside membership.
 
-        **Usage.** A per-user fee that changes monthly based on who has used your hub, with a rate that levels off as your monthly users grows so that heavy usage doesn't result in runaway costs.
+        **Usage.** A per-user fee that changes monthly based on who has used your hub, with a rate that levels off as your monthly users grow so that heavy usage doesn't result in runaway costs.
 
         **Cloud.** You can bring your own cloud acount and manage cloud spending on your own (we'll just need access to the infrastructure). We can also manage cloud spending on your behalf, and will pass through your cloud costs with no usage-based markup. You can track cloud spend in dashboards, get alerts before it runs over, and read [how cloud costs work and how to control them](https://docs.2i2c.org/community-lead/billing/overview/).
 

--- a/content/membership/_index.md
+++ b/content/membership/_index.md
@@ -6,32 +6,27 @@ sections:
   - block: markdown
     id: intro
     content:
-      title: Membership in 2i2c
+      title: Membership with 2i2c
       subtitle: Join a network of communities building shared open infrastructure
       text: |
-        As a non-profit, we believe the best infrastructure comes from co-creation. Our membership model pools resources across research and education communities to operate [shared infrastructure](/platform) and to improve the [open source tools](/open-practices/#projects) everyone depends on.
+        As a non-profit, we run [shared, open infrastructure](/platform) for research and education communities. Membership pools resources so that one team can operate everyone's hubs and improve the [open source tools](/open-practices/#projects) you depend on.
 
-        When you become a member, your community joins a network where usage shapes development priorities, improvements flow back to open source, and everyone benefits.
+        That work spans four areas: **operating** your infrastructure, **building** software your community needs, **stewarding** upstream open source projects, and **connecting and advising** communities and funders. These fuel the cycle you see below:
 
-        {{< figure src="images/collaborative-model.png" alt="Diagram showing the collaborative model: member communities use their hub to have impact, they influence our open roadmap with feedback and co-funding, which drives contributions across the open source ecosystem, which creates better tools for our members and for the world." caption="Our collaborative development and operations model." >}}
+        {{< figure src="images/collaborative-model.png" alt="Diagram showing the collaborative model: member communities use their hub to have impact, they influence our open roadmap with feedback and co-funding, which drives contributions across the open source ecosystem, which creates better tools for our members and for the world." caption="How our collaborative development and operations model improves the open source ecosystem, and leads to better technology for our managed community hubs." >}}
 
-        **Shared operations.** One infrastructure team manages hubs for all member communities using a [shared infrastructure repository](https://github.com/2i2c-org/infrastructure). Each community gets their own hub customized to their needs, while benefiting from shared expertise, faster incident response, and improvements deployed everywhere at once.
-
-        **Shared development.** Members influence [our open roadmap](https://2i2c.org/roadmap) with feedback and co-funding. This drives contributions across the open source ecosystem, creating better tools for the world and improvements that we can rapidly deploy to our member hubs.
-
-        Learn more about [our mission](/mission) and the values that drive our work.
+        Membership also connects you with a network of [member communities](/members) that mutually support one another: a problem solved for one community becomes an improvement shared by all. Members co-fund and steer [our open roadmap](https://2i2c.org/roadmap), and those improvements flow back to the open source ecosystem. Learn more about [our mission](/mission) or [explore the platform](/platform).
 
   - block: features
     id: personas
     content:
       title: What members get
-      subtitle: Our platform serves researchers, administrators, and community leaders with different needs.
       items:
         - name: For your community
           icon: laptop-code
           icon_pack: fas
           description: |
-            Ready-to-use cloud environments with your community's tools, data, and computational resources. Focus on discovery, not server management. Shared environments for reproducible collaboration.
+            Ready-to-use cloud environments with your community's tools, data, and computational resources. Your community focuses on discovery while we manage the servers. Shared environments for reproducible collaboration.
         - name: For hub administrators
           icon: cogs
           icon_pack: fas
@@ -44,27 +39,12 @@ sections:
             Pool resources with other communities for greater impact. Influence 2i2c's roadmap and priorities. Support open source sustainability.
 
   - block: markdown
-    id: engagement
-    content:
-      title: Membership and project work
-      text: |
-        We offer two ways to work together:
-
-        **Membership** provides ongoing access to our managed hub platform. Membership fees sustain operations and support [foundational open source contributions](../blog/2025/foundational-contributions/) that benefit all members.
-
-        **Project collaborations** let organizations fund specific development work that addresses shared challenges. Project work accelerates [our roadmap](https://2i2c.org/roadmap) and creates improvements deployed across the network.
-
-        Many organizations do both: membership for day-to-day infrastructure, plus project funding for strategic priorities. See [our collaborators and funders](/collaborators) for examples of organizations we work with, or read more about [our service model](https://compass.2i2c.org/organization/service-model/).
-
-        {{< cta cta_text="Learn about our platform" cta_link="/platform" cta_new_tab="false" >}}
-
-  - block: markdown
     id: commitments
     content:
       title: Our commitments
       subtitle: We make specific commitments to ensure your infrastructure remains open, portable, and community-controlled.
       text: |
-        We guarantee your [Right to Replicate](/right-to-replicate) - your infrastructure configuration is transparent and portable, so you're never locked in. All our engineering work is [open source](/open-technology) with licensing that protects communities. We work transparently and [contribute upstream](https://2i2c.org/kpis/upstream/) to the projects we depend on.
+        Your [Right to Replicate](/right-to-replicate) keeps your configuration transparent and portable, so you're never locked in. All our engineering work is [open source](/open-technology) with licensing that protects communities, and we [contribute upstream](https://2i2c.org/kpis/upstream/) to the projects we depend on. Our hubs are [secure by default](https://docs.2i2c.org/admin/security/security-foundations/), with isolated user environments and continuous monitoring.
 
         See [our public roadmap](https://2i2c.org/roadmap) for current priorities, or read more about [our open practices](/open-practices).
 
@@ -73,5 +53,21 @@ sections:
     content:
       title: Membership options and pricing
       text: |
-        {{< cta cta_text="See membership options" cta_link="/join" cta_new_tab="false" >}}
+        <!-- MAINTAINER NOTE: the $15k / $50k caps and "free above 10,000 users" also appear on sales.2i2c.org/service-description and compass pricing-strategy.md. If a figure changes, update all three. -->
+        Your total cost is predictable and bounded: a fixed annual fee, a usage fee that caps as your community grows, and cloud passed through at cost.
+
+        **Base membership.** A fixed annual fee at one of two tiers. Both cover all four areas of our work; they differ in how much time and strategic attention you get.
+
+        - **General**: For communities that want to benefit from our core shared platform and team. We operate your hub, support your community, and include you in the building, stewarding, and connecting we do for the whole network.
+        - **Premier**: For communities that want to support open source, our mission, and who want deeper engagement with our team. Includes more service hours across all four areas, plus a deeper strategic relationship, including optional monthly strategy sessions, quarterly roadmap reviews, and collaborative work time with our team.
+
+        See [the service description](https://sales.2i2c.org/service-description) for the services included with each tier.
+
+        **Directed engagements.** Fund extra dedicated work in any of the four areas described above. For example, you can support development from [our roadmap](https://2i2c.org/roadmap), more complex infrastructure operations, or dedicated upstream stewardship time. Some organizations also fund larger [project collaborations](/collaborators) alongside membership.
+
+        **Usage.** A per-user fee that changes monthly based on who has used your hub, with a rate that levels off as your monthly users grows so that heavy usage doesn't result in runaway costs.
+
+        **Cloud.** You can bring your own cloud acount and manage cloud spending on your own (we'll just need access to the infrastructure). We can also manage cloud spending on your behalf, and will pass through your cloud costs with no usage-based markup. You can track cloud spend in dashboards, get alerts before it runs over, and read [how cloud costs work and how to control them](https://docs.2i2c.org/community-lead/billing/overview/).
+
+        {{< cta cta_text="Get started" cta_link="/join" cta_new_tab="false" >}}
 ---

--- a/content/membership/_index.md
+++ b/content/membership/_index.md
@@ -11,7 +11,7 @@ sections:
       text: |
         As a non-profit, we run [shared, open infrastructure](/platform) for research and education communities. Membership pools resources so that one team can operate everyone's hubs and improve the [open source tools](/open-practices/#projects) you depend on.
 
-        That work spans four areas: **operating** your infrastructure, **building** software your community needs, **stewarding** upstream open source projects, and **connecting and advising** communities and funders. These fuel the cycle you see below:
+        That work spans four areas (informally called "DOCS"): **Developing** software your community needs, **Operating** infrastructure, **Connecting & advising** communities with information and resources, and **Stewarding** upstream open source projects. These fuel the cycle you see below:
 
         {{< figure src="images/collaborative-model.png" alt="Diagram showing the collaborative model: member communities use their hub to have impact, they influence our open roadmap with feedback and co-funding, which drives contributions across the open source ecosystem, which creates better tools for our members and for the world." caption="How our collaborative development and operations model improves the open source ecosystem, and leads to better technology for our managed community hubs." >}}
 
@@ -57,18 +57,18 @@ sections:
         so make sure to mirror the changes! -->
         Membership is a fixed annual amount that supports our mission and key member services. Where we run infrastructure for members, we add bounded usage costs to cover the time and cloud fees that we incur with extra usage.
 
-        **Base membership.** A fixed annual fee at one of two tiers. Both cover all four areas of our work. They differ in how much time and strategic attention you get.
+        **Base membership.** A fixed annual fee at one of two tiers. Both cover all four DOCS areas of our work. They differ in how much time and strategic attention you get.
 
         - **General**: For communities that want to benefit from our core shared platform and team. We'll operate your hub, support your community, and steward open source projects on your behalf.
-        - **Premier**: For communities that want to support open source, our mission, and who want deeper engagement with our team and member network. Includes more service hours across all four areas, plus a deeper strategic relationship, including optional monthly strategy sessions, quarterly roadmap reviews, and collaborative work time with our team.
+        - **Premier**: For communities that want to support open source and our mission, and want deeper engagement with our team and member network. Includes more service hours across all four areas, plus a deeper strategic relationship, including optional monthly strategy sessions, quarterly roadmap reviews, and collaborative work time with our team.
 
         See [the service description](https://sales.2i2c.org/service-description) for the services included with each tier.
 
-        **Directed engagements.** Fund extra dedicated work in any of the four areas described above. For example, you can support development from [our roadmap](https://2i2c.org/roadmap), more complex infrastructure operations, or dedicated upstream stewardship time. Some organizations also fund larger [project collaborations](/collaborators) alongside membership.
+        **Directed engagements.** Fund extra dedicated work in any of the four DOCS areas described above. For example, you can support development from [our roadmap](https://2i2c.org/roadmap), more complex infrastructure operations, or dedicated upstream stewardship time. Some organizations also fund larger [project collaborations](/collaborators) alongside membership.
 
         **Usage.** A per-user fee that changes monthly based on who has used your hub, with a rate that levels off as your monthly users grow so that heavy usage doesn't result in runaway costs.
 
-        **Cloud.** You can bring your own cloud acount and manage cloud spending on your own (we'll just need access to the infrastructure). We can also manage cloud spending on your behalf, and will pass through your cloud costs with no usage-based markup. You can track cloud spend in dashboards, get alerts before it runs over, and read [how cloud costs work and how to control them](https://docs.2i2c.org/community-lead/billing/overview/).
+        **Cloud.** You can bring your own cloud account and manage cloud spending on your own (we'll just need access to the infrastructure). We can also manage cloud spending on your behalf, and will pass through your cloud costs with no usage-based markup. You can track cloud spend in dashboards, get alerts before it runs over, and read [how cloud costs work and how to control them](https://docs.2i2c.org/community-lead/billing/overview/).
 
         {{< cta cta_text="Get started" cta_link="/join" cta_new_tab="false" >}}
 ---

--- a/content/membership/_index.md
+++ b/content/membership/_index.md
@@ -72,7 +72,7 @@ sections:
 
         **Cloud.** Bring your own cloud account and manage spending yourself (we'll just need access to the infrastructure), or have us manage it and pass through your cloud costs with no usage-based markup. Either way, you can track cloud spend in dashboards, get alerts before it runs over, and read [how cloud costs work and how to control them](https://docs.2i2c.org/community-lead/billing/overview/).
 
-        **Getting started.** Most hubs can be set up in a few weeks. The timeline usually depends on how quickly your community settles on what it needs, and we'll help you work through those decisions.
+        **Getting started.** The timeline is usually influenced by how quickly your community settles on what it needs. Most hubs are set up in a few days, once these decisions are made. Figuring out the needs is not trivial and might take a few weeks on its own, but we'll guide you through the process.
 
         {{< cta cta_text="Get started" cta_link="/join" cta_new_tab="false" >}}
 ---

--- a/content/membership/_index.md
+++ b/content/membership/_index.md
@@ -9,13 +9,13 @@ sections:
       title: Membership with 2i2c
       subtitle: Join a network of communities building shared open infrastructure
       text: |
-        As a non-profit, we run [shared, open infrastructure](/platform) for research and education communities. Membership pools resources so that one team can operate everyone's hubs and improve the [open source tools](/open-practices/#projects) you depend on.
+        As a non-profit, we run [shared, open infrastructure](/platform) for research and education communities. Each member community gets a hub: a flexible cloud workspace with its own software, data, and compute. Membership pools resources so that one team can operate every hub and improve the [open source tools](/open-practices/#projects) you depend on.
 
         That work spans four areas (informally called "DOCS"): **Developing** software your community needs, **Operating** infrastructure, **Connecting & advising** communities with information and resources, and **Stewarding** upstream open source projects. These fuel the cycle you see below:
 
-        {{< figure src="images/collaborative-model.png" alt="Diagram showing the collaborative model: member communities use their hub to have impact, they influence our open roadmap with feedback and co-funding, which drives contributions across the open source ecosystem, which creates better tools for our members and for the world." caption="How our collaborative development and operations model improves the open source ecosystem, and leads to better technology for our managed community hubs." >}}
+        {{< figure src="images/collaborative-model.png" alt="Diagram showing the collaborative model: member communities use their hub to have impact, they influence our open roadmap with feedback and co-funding, which drives contributions across the open source ecosystem, which creates better tools for our members and for the world." caption="Member communities steer our roadmap, and the improvements flow back to the open source ecosystem and to every hub." >}}
 
-        Membership also connects you with a network of [member communities](/members) that mutually support one another: a problem solved for one community becomes an improvement shared by all. Members co-fund and steer [our open roadmap](https://2i2c.org/roadmap), and those improvements flow back to the open source ecosystem. Learn more about [our mission](/mission) or [explore the platform](/platform).
+        Membership also connects you with a network of [member communities](/members) that support one another: a problem solved for one becomes an improvement shared by all. Members co-fund and steer [our open roadmap](https://2i2c.org/roadmap). Learn more about [our mission](/mission) or [explore the platform](/platform).
 
   - block: features
     id: personas
@@ -31,7 +31,7 @@ sections:
           icon: cogs
           icon_pack: fas
           description: |
-            Community-standard infrastructure you could run yourself. Manage users and monitor your community's usage. Automatic upstream improvements and full transparency via the Right to Replicate.
+            Community-standard infrastructure you could run yourself. Manage users and monitor your community's usage. Automatic upstream improvements and full transparency via the Right to Replicate. You'll also join a peer network of hub administrators solving similar challenges.
         - name: For community leaders
           icon: users
           icon_pack: fas
@@ -42,7 +42,7 @@ sections:
     id: commitments
     content:
       title: Our commitments
-      subtitle: We make specific commitments to ensure your infrastructure remains open, portable, and community-controlled.
+      subtitle: Your infrastructure stays open, portable, and community-controlled.
       text: |
         Your [Right to Replicate](/right-to-replicate) keeps your configuration transparent and portable, so you're never locked in. All our engineering work is [open source](/open-technology) with licensing that protects communities, and we [contribute upstream](https://2i2c.org/kpis/upstream/) to the projects we depend on. Our hubs are [secure by default](https://docs.2i2c.org/admin/security/security-foundations/), with isolated user environments and continuous monitoring.
 
@@ -55,20 +55,24 @@ sections:
       text: |
         <!-- NOTE: the numbers here also appear at sales.2i2c.org/service-description
         so make sure to mirror the changes! -->
-        Membership is a fixed annual amount that supports our mission and key member services. Where we run infrastructure for members, we add bounded usage costs to cover the time and cloud fees that we incur with extra usage.
+        Membership is a fixed annual amount that supports our mission and key member services. Where we run infrastructure for members, we add bounded usage costs to cover the extra time and cloud fees.
 
-        **Base membership.** A fixed annual fee at one of two tiers. Both cover all four DOCS areas of our work. They differ in how much time and strategic attention you get.
+        **Base membership.** A fixed annual fee at one of two tiers. Both give you the benefits of all four areas of our work. They differ in how much time and strategic attention you get.
 
-        - **General**: For communities that want to benefit from our core shared platform and team. We'll operate your hub, support your community, and steward open source projects on your behalf.
-        - **Premier**: For communities that want to support open source and our mission, and want deeper engagement with our team and member network. Includes more service hours across all four areas, plus a deeper strategic relationship, including optional monthly strategy sessions, quarterly roadmap reviews, and collaborative work time with our team.
+        - **General**: For communities that want to benefit from our core shared platform and team. We'll operate your hub, support your community, and steward open source projects on your behalf. General membership doesn't cover the cost of new development, but you'll still benefit from the work that Premier members and directed engagements fund.
+        - **Premier**: For communities that want to support open source and our mission, and want deeper engagement with our team and member network. Includes more service hours across all four areas and a deeper strategic relationship: optional monthly strategy sessions, quarterly roadmap reviews, and collaborative work time with our team.
+
+        You don't need a hub to be a member: members without infrastructure pay only the annual fee, and some direct their support toward the open source projects their communities depend on. Others join an existing community's hub and share its operating costs instead of running their own.
 
         See [the service description](https://sales.2i2c.org/service-description) for the services included with each tier.
 
-        **Directed engagements.** Fund extra dedicated work in any of the four DOCS areas described above. For example, you can support development from [our roadmap](https://2i2c.org/roadmap), more complex infrastructure operations, or dedicated upstream stewardship time. Some organizations also fund larger [project collaborations](/collaborators) alongside membership.
+        **Directed engagements.** Fund extra dedicated work in any of the four areas described above. For example, you can support development from [our roadmap](https://2i2c.org/roadmap), more complex infrastructure operations, or dedicated upstream stewardship time. Some organizations also fund larger [project collaborations](/collaborators) alongside membership. We'll scope the work together and come up with a plan for invoicing and cost recovery.
 
-        **Usage.** A per-user fee that changes monthly based on who has used your hub, with a rate that levels off as your monthly users grow so that heavy usage doesn't result in runaway costs.
+        **Usage.** A per-user fee that changes monthly based on who has used your hub. The rate levels off as your monthly users grow, and stops entirely above a certain size, so there's a maximum monthly fee no matter how large your community gets.
 
-        **Cloud.** You can bring your own cloud account and manage cloud spending on your own (we'll just need access to the infrastructure). We can also manage cloud spending on your behalf, and will pass through your cloud costs with no usage-based markup. You can track cloud spend in dashboards, get alerts before it runs over, and read [how cloud costs work and how to control them](https://docs.2i2c.org/community-lead/billing/overview/).
+        **Cloud.** Bring your own cloud account and manage spending yourself (we'll just need access to the infrastructure), or have us manage it and pass through your cloud costs with no usage-based markup. Either way, you can track cloud spend in dashboards, get alerts before it runs over, and read [how cloud costs work and how to control them](https://docs.2i2c.org/community-lead/billing/overview/).
+
+        **Getting started.** Most hubs can be set up in a few weeks. The timeline usually depends on how quickly your community settles on what it needs, and we'll help you work through those decisions.
 
         {{< cta cta_text="Get started" cta_link="/join" cta_new_tab="false" >}}
 ---

--- a/content/open-practices/index.md
+++ b/content/open-practices/index.md
@@ -55,7 +55,7 @@ sections:
     content:
       title: Our role in the open source ecosystem
       text: |
-        We strive to be a co-leader, maintainer, and contributor to the open source projects that we work with, not an "owner" or a gatekeeper. We help these communities grow large, diverse, multi-stakeholder teams of contributors, and we take on leadership roles so that we can support projects at a strategic level. The technology we build is by and for the commons - we are a part of that ecosystem, but do not own or control it.
+        We strive to be a co-leader, maintainer, and contributor to the open source projects that we work with, not an "owner" or a gatekeeper. We help these communities grow large, diverse, multi-stakeholder teams of contributors, and we take on leadership roles so that we can support projects at a strategic level. While we may incubate projects in our own repositories for a time, our goal is to move them into multi-stakeholder, community-maintained spaces. The technology we build is by and for the commons - we are a part of that ecosystem, but do not own or control it.
 
   - block: markdown
     id: projects

--- a/content/open-practices/index.md
+++ b/content/open-practices/index.md
@@ -55,7 +55,7 @@ sections:
     content:
       title: Our role in the open source ecosystem
       text: |
-        We strive to be a co-leader, maintainer, and contributor to the open source projects that we work with, not an "owner" or a gatekeeper. Our goal is to help open source communities grow large, diverse, multi-stakeholder teams of contributors. We aim to have leadership roles in these projects, so that we can support them at a strategic level. In short: the technology we build is by and for the commons - we are a part of that ecosystem, but do not own or control it.
+        We strive to be a co-leader, maintainer, and contributor to the open source projects that we work with, not an "owner" or a gatekeeper. We help these communities grow large, diverse, multi-stakeholder teams of contributors, and we take on leadership roles so that we can support projects at a strategic level. The technology we build is by and for the commons - we are a part of that ecosystem, but do not own or control it.
 
   - block: markdown
     id: projects

--- a/content/open-practices/index.md
+++ b/content/open-practices/index.md
@@ -37,7 +37,7 @@ sections:
     content:
       title: Upstream contributions
       text: |
-        We take an [upstream first](https://compass.2i2c.org/open-source/strategy/#upstream-first) approach — improvements we build flow back to the open source projects they came from. We provide both [directed and foundational contributions](blog/2025/good-citizen/index.md) and [track our upstream impact](https://2i2c.org/kpis/upstream/) publicly. This work is funded through our [membership and co-development model](/membership).
+        We take an [upstream first](https://compass.2i2c.org/open-source/strategy/#upstream-first) approach - improvements we build flow back to the open source projects they came from. We provide both [directed and foundational contributions](blog/2025/good-citizen/index.md) and [track our upstream impact](https://2i2c.org/kpis/upstream/) publicly. This work is funded through our [membership and co-development model](/membership).
 
   - block: markdown
     id: transparent
@@ -47,6 +47,15 @@ sections:
       title: Transparency
       text: |
         We do our work openly. We are transparent about [organizations that support and fund us](../about/funding/index.md), communicate [in-progress work on our blog](blog/2025/communications-strategy/index.md), and publish [our roadmap](https://2i2c.org/roadmap) and [collaborators](/collaborators) for anyone to see.
+
+  - block: markdown
+    id: ecosystem-role
+    design:
+      columns: 2
+    content:
+      title: Our role in the open source ecosystem
+      text: |
+        We strive to be a co-leader, maintainer, and contributor to the open source projects that we work with, not an "owner" or a gatekeeper. Our goal is to help open source communities grow large, diverse, multi-stakeholder teams of contributors. We aim to have leadership roles in these projects, so that we can support them at a strategic level. In short: the technology we build is by and for the commons - we are a part of that ecosystem, but do not own or control it.
 
   - block: markdown
     id: projects

--- a/content/platform/_index.md
+++ b/content/platform/_index.md
@@ -1,6 +1,6 @@
 ---
 # Page title
-title: Hub service
+title: Platform & Infrastructure
 # Page type - we want a landing page (such as a homepage)
 type: landing
 aliases:
@@ -26,10 +26,12 @@ sections:
     content:
       title: Sign-in
       text: |
-        We support the following authentication and authorization options:
-          - **GitHub** - with support for GitHub Organization and Teams
-          - **CILogon** - with support for institutional logins, Google Auth, Microsoft, and ORCID
-          - **Shared Password** - simple authentication with a global shared password, ideal for workshops and webinar
+        We support the following [authentication and authorization options](https://docs.2i2c.org/admin/user-management/authentication-and-access/):
+
+        - **GitHub** - with support for GitHub Organization and Teams
+        - **CILogon** - with support for institutional logins, Google Auth, Microsoft, and ORCID
+        - **Shared Password** - simple authentication with a global shared password, ideal for workshops and webinars
+        - **Other providers** - we also run direct Google sign-in and other standard single-sign-on providers. Ask us about yours.
 
         <figure class="videofigure">
           {{< video src="videos/jupyterhub-admin.mp4">}}
@@ -91,7 +93,7 @@ sections:
           </figcaption>
         </figure>
 
-        Hub users can also configure hubs with any pre-built image from [Docker Hub](https://hub.docker.com/) or [quay.io](https://quay.io), or provide their own self-maintained images.
+        Hub users can also configure hubs with any pre-built image from [Docker Hub](https://hub.docker.com/) or [quay.io](https://quay.io), or provide their own self-maintained images. Users can even [build environments themselves](https://docs.2i2c.org/user/environment/dynamic-imagebuilding/) from a GitHub repository, right from the hub.
 
         {{< softwarestacklogos >}}
 


### PR DESCRIPTION
This builds on https://github.com/2i2c-org/meta/issues/3406 by incorporating more language about "multiple areas of service, aka DOCS" into our brochure site.

It tries to soften the idea that membership is just about getting a hub, describes the other ways that we provide services in a contract, describes a bit more about directed engagements etc, and cleans up a few other ways we talk about the infrastructure here and there.

---

- closes https://github.com/2i2c-org/meta/issues/3407