### PR TITLE
fix: correct 'contirbutions' to 'contributions' typo in collaborators page

### DIFF
--- a/content/collaborators/_index.md
+++ b/content/collaborators/_index.md
@@ -61,7 +61,7 @@ sections:
         
         _How we define types of collaborators_.
 
-        **Members** are part of [our member network](../members/) that contribute extra funding and time. These are for contirbutions beyond the [Foundational impact](blog/2025/good-citizen/index.md) that membership fees support.
+        **Members** are part of [our member network](../members/) that contribute extra funding and time. These are for contributions beyond the [Foundational impact](blog/2025/good-citizen/index.md) that membership fees support.
         
         **Funders** primarily have impact by funding initiatives that we benefit from. We include funders when they directly benefit 2i2c or a project on which we collaborate, but not every funder for every member and collaborator that supports us.
         


### PR DESCRIPTION
## Description
Fixes a simple typo in the collaborators documentation page.

**File:** content/collaborators/_index.md line 64

**Before:** These are for contirbutions beyond the...
**After:** These are for contributions beyond the...

## Checklist
- [x] Scope: surgical typo fix (1 word)
- [x] Issue linked: #623
- [x] Commit email: 166608075+Jah-yee@users.noreply.github.com
- [x] Single commit